### PR TITLE
Add MEMORY slot and multi-card memory handling

### DIFF
--- a/CardManager.gd
+++ b/CardManager.gd
@@ -55,14 +55,23 @@ func start_drag(card):
 
 func finish_drag():
 	var card_slot_found = raycast_check_for_card_single_slot()
-	if card_slot_found and not card_slot_found.card_in_slot:
-		card_being_dragged.position = card_slot_found.position
-		card_being_dragged.get_node("Area2D/CollisionShape2D").disabled = true
-		card_slot_found.card_in_slot = true
-		card_being_dragged.scale = hover_scale
-		card_being_dragged.z_index = base_z_index
-		if card_slot_found.name == "90DegreesCardSlot" or card_slot_found.is_in_group("rotated_slots"):
-			card_being_dragged.rotation_degrees = -90
+	if card_slot_found:
+		if card_slot_found.name == "MEMORY":
+			card_slot_found.add_card_to_memory(card_being_dragged)
+			card_being_dragged.get_node("Area2D/CollisionShape2D").disabled = true
+			card_being_dragged.scale = hover_scale
+			card_being_dragged.z_index = base_z_index
+		elif not card_slot_found.card_in_slot:
+			card_being_dragged.position = card_slot_found.position
+			card_being_dragged.get_node("Area2D/CollisionShape2D").disabled = true
+			card_slot_found.card_in_slot = true
+			card_being_dragged.scale = hover_scale
+			card_being_dragged.z_index = base_z_index
+			if card_slot_found.name == "90DegreesCardSlot" or card_slot_found.is_in_group("rotated_slots"):
+				card_being_dragged.rotation_degrees = -90
+		else:
+			card_being_dragged.z_index = base_z_index + card_counter
+			card_counter += 1
 	else:
 		card_being_dragged.z_index = base_z_index + card_counter
 		card_counter += 1

--- a/Main.tscn
+++ b/Main.tscn
@@ -1,10 +1,12 @@
-[gd_scene load_steps=6 format=3 uid="uid://dqt16mao7lo7t"]
+[gd_scene load_steps=8 format=3 uid="uid://dqt16mao7lo7t"]
 
 [ext_resource type="Script" uid="uid://btk4g07uwv3gi" path="res://CardManager.gd" id="1_uu6xs"]
 [ext_resource type="PackedScene" uid="uid://bdq4b32kkn1di" path="res://Card.tscn" id="2_r0du0"]
 [ext_resource type="PackedScene" uid="uid://ml3qhw1idgmk" path="res://CardsSlotForSingleCard.tscn" id="4_fos0i"]
 [ext_resource type="PackedScene" uid="uid://bibopkgjli11i" path="res://90DegreesCardSlot.tscn" id="5_3dxm6"]
 [ext_resource type="Texture2D" uid="uid://ctvk61fkpt3vm" path="res://Field_ga.png" id="5_fos0i"]
+[ext_resource type="PackedScene" uid="uid://d2vjqup3tyk8n" path="res://Memory.tscn" id="6_lgr22"]
+[ext_resource type="Script" uid="uid://drubil22n7oyl" path="res://MemoryCardsSlot.gd" id="7_trn2v"]
 
 [node name="Main" type="Node2D"]
 
@@ -14,12 +16,10 @@ script = ExtResource("1_uu6xs")
 
 [node name="Card" parent="CardManager" instance=ExtResource("2_r0du0")]
 position = Vector2(253, 553)
-scale = Vector2(0.348748, 0.348748)
 
 [node name="Card2" parent="CardManager" instance=ExtResource("2_r0du0")]
 z_index = 1
 position = Vector2(253, 152)
-scale = Vector2(0.348748, 0.348748)
 
 [node name="GAField" type="Node2D" parent="."]
 
@@ -48,3 +48,7 @@ scale = Vector2(0.972429, 0.971529)
 
 [node name="BANISH" parent="GAField" instance=ExtResource("5_3dxm6")]
 position = Vector2(1342, 647)
+
+[node name="MEMORY" parent="GAField" instance=ExtResource("6_lgr22")]
+position = Vector2(974, 978)
+script = ExtResource("7_trn2v")

--- a/Memory.tscn
+++ b/Memory.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=2 format=3 uid="uid://d2vjqup3tyk8n"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_sellp"]
+size = Vector2(649, 131)
+
+[node name="MEMORY" type="Node2D"]
+
+[node name="Area2D" type="Area2D" parent="."]
+light_mask = 2
+visibility_layer = 2
+collision_layer = 2
+collision_mask = 0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
+shape = SubResource("RectangleShape2D_sellp")

--- a/MemoryCardsSlot.gd
+++ b/MemoryCardsSlot.gd
@@ -1,0 +1,86 @@
+extends Node2D
+
+var cards_in_slot = []
+var base_position
+
+func _ready() -> void:
+	base_position = Vector2.ZERO
+
+func add_card_to_memory(card):
+	cards_in_slot.append(card)
+	arrange_cards_symmetrically()
+
+func insert_card_at_position(card, index):
+	if index < 0:
+		index = 0
+	elif index > cards_in_slot.size():
+		index = cards_in_slot.size()
+	
+	cards_in_slot.insert(index, card)
+	arrange_cards_symmetrically()
+
+func add_card_near_position(card, target_x_position):
+	var slot_width = get_slot_width()
+	var slot_start = global_position.x - slot_width/2
+	var slot_end = global_position.x + slot_width/2
+	
+	target_x_position = clamp(target_x_position, slot_start, slot_end)
+	
+	var best_index = cards_in_slot.size() 
+	
+	if cards_in_slot.size() > 0:
+		for i in range(cards_in_slot.size()):
+			if target_x_position < cards_in_slot[i].global_position.x:
+				best_index = i
+				break
+	insert_card_at_position(card, best_index)
+
+func arrange_cards_symmetrically():
+	var card_count = cards_in_slot.size()
+	var slot_width = get_slot_width()
+	if card_count == 1:
+		cards_in_slot[0].global_position = global_position
+	else:
+		var positions = []
+		if card_count == 2:
+			positions = [0.33, 0.67]
+		elif card_count == 3:
+			positions = [0.25, 0.5, 0.75]
+		elif card_count == 4:
+			positions = [0.2, 0.4, 0.6, 0.8]
+		elif card_count == 5:
+			positions = [0.15, 0.325, 0.5, 0.675, 0.85]
+		elif card_count == 6:
+			positions = [0.125, 0.275, 0.425, 0.575, 0.725, 0.875]
+		else:
+			var min_pos = 0.07
+			var max_pos = 0.93
+			
+			for i in range(card_count):
+				var normalized_pos
+				if card_count == 1:
+					normalized_pos = 0.5
+				else:
+					normalized_pos = min_pos + (max_pos - min_pos) * i / (card_count - 1)
+				positions.append(normalized_pos)
+		
+		for i in range(card_count):
+			var normalized_x = positions[i]
+			var actual_x = global_position.x - slot_width/2 + normalized_x * slot_width
+			cards_in_slot[i].global_position = Vector2(actual_x, global_position.y)
+
+func get_slot_width():
+	var area = get_node("Area2D")
+	if area:
+		var collision_shape = area.get_node("CollisionShape2D")
+		if collision_shape and collision_shape.shape:
+			return collision_shape.shape.size.x
+	return 400
+
+func get_slot_height():
+	var area = get_node("Area2D")
+	if area:
+		var collision_shape = area.get_node("CollisionShape2D")
+		if collision_shape and collision_shape.shape:
+			return collision_shape.shape.size.y
+	return 100

--- a/MemoryCardsSlot.gd.uid
+++ b/MemoryCardsSlot.gd.uid
@@ -1,0 +1,1 @@
+uid://drubil22n7oyl


### PR DESCRIPTION
Introduced a MEMORY slot to the scene and implemented MemoryCardsSlot.gd to support multiple cards in the MEMORY area, including logic for arranging cards symmetrically. Updated CardManager.gd to handle dropping cards into the MEMORY slot, and added new card instances and scene references in Main.tscn.