### PR TITLE
Integrate card database and update card drawing logic

### DIFF
--- a/Scenes/Card.tscn
+++ b/Scenes/Card.tscn
@@ -12,7 +12,7 @@ position = Vector2(1360.5, 780)
 scale = Vector2(0.387084, 0.388501)
 script = ExtResource("1_hael8")
 
-[node name="GaBack" type="Sprite2D" parent="."]
+[node name="CardImage" type="Sprite2D" parent="."]
 scale = Vector2(0.492, 0.492)
 texture = ExtResource("2_3p273")
 

--- a/Scripts/CardDatabase.gd
+++ b/Scripts/CardDatabase.gd
@@ -1,0 +1,5 @@
+const CARDS = {
+	"academy-guide-p24" : [],
+	"absolving-flames-amb": [],
+	"acolyte-of-cultivation-amb" : []
+}

--- a/Scripts/GA_DECK.gd
+++ b/Scripts/GA_DECK.gd
@@ -1,21 +1,25 @@
 extends Node2D
 
-var player_deck = ["spirit-of-water", "spirit-of-water","spirit-of-water"]
+var player_deck = ["academy-guide-p24", "absolving-flames-amb","acolyte-of-cultivation-amb"]
+var card_database_reference
 
 const CARD_SCENE_PATH = "res://Scenes/Card.tscn"
 
-func free() -> void:
-	pass
+func _ready() -> void:
+	player_deck.shuffle()
+	card_database_reference = preload("res://Scripts/CardDatabase.gd")
 
 func draw_card():
-	var card_drawn = player_deck[0]
-	player_deck.erase(card_drawn)
+	var card_drawn_name = player_deck[0]
+	player_deck.erase(card_drawn_name)
 	
 	if player_deck.size() == 0:
 		$Area2D/CollisionShape2D.disabled = true
 		$Sprite2D.visible = false
 	var card_scene = preload(CARD_SCENE_PATH)
 	var new_card = card_scene.instantiate()
+	var card_image_path = str("res://Assets/Grand Archive/Card Images/" + card_drawn_name + ".png")
+	new_card.get_node("CardImage").texture = load(card_image_path)
 	$"../CardManager".add_child(new_card)
 	new_card.name = "Card"
 	$"../PlayerHand".add_card_to_hand(new_card)

--- a/project.godot
+++ b/project.godot
@@ -26,7 +26,3 @@ window/stretch/mode="canvas_items"
 [dotnet]
 
 project/assembly_name="New Game Project"
-
-[rendering]
-
-textures/canvas_textures/default_texture_filter=2


### PR DESCRIPTION
Renamed 'GaBack' node to 'CardImage' in Card.tscn for clarity. Added CardDatabase.gd to store card data. Updated GA_DECK.gd to use new card names, shuffle deck on ready, and dynamically load card images based on drawn card. Minor cleanup in project.godot.