### PR TITLE
Add card flip animation to card draw

### DIFF
--- a/Scenes/Card.tscn
+++ b/Scenes/Card.tscn
@@ -1,10 +1,118 @@
-[gd_scene load_steps=4 format=3 uid="uid://bdq4b32kkn1di"]
+[gd_scene load_steps=7 format=3 uid="uid://bdq4b32kkn1di"]
 
 [ext_resource type="Script" uid="uid://qtrh38o1lpkw" path="res://Scripts/Card.gd" id="1_hael8"]
 [ext_resource type="Texture2D" uid="uid://yaxuiipbxmdg" path="res://Assets/Grand Archive/ga_back.png" id="2_3p273"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_hael8"]
 size = Vector2(246, 344)
+
+[sub_resource type="Animation" id="Animation_3p273"]
+resource_name = "card_flip"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("CardImageBack:scale")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.1, 0.2),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector2(0.492, 0.492), Vector2(0.1, 0.492), Vector2(0.492, 0.492)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("CardImageBack:z_index")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.1),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [0, -1]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("CardImage:z_index")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 0.1),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [-1, 0]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("CardImage:scale")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.1, 0.2),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector2(0.492, 0.492), Vector2(0.1, 0.492), Vector2(0.492, 0.492)]
+}
+
+[sub_resource type="Animation" id="Animation_h8wm0"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("CardImageBack:scale")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(0.492, 0.492)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("CardImageBack:z_index")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [0]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("CardImage:z_index")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [-1]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("CardImage:scale")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(0.492, 0.492)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_h8wm0"]
+_data = {
+&"RESET": SubResource("Animation_h8wm0"),
+&"card_flip": SubResource("Animation_3p273")
+}
 
 [node name="Card" type="Node2D"]
 z_index = -2
@@ -13,7 +121,12 @@ position = Vector2(1360.5, 780)
 scale = Vector2(0.39, 0.39)
 script = ExtResource("1_hael8")
 
+[node name="CardImageBack" type="Sprite2D" parent="."]
+scale = Vector2(0.492, 0.492)
+texture = ExtResource("2_3p273")
+
 [node name="CardImage" type="Sprite2D" parent="."]
+z_index = -1
 scale = Vector2(0.492, 0.492)
 texture = ExtResource("2_3p273")
 
@@ -21,6 +134,11 @@ texture = ExtResource("2_3p273")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
 shape = SubResource("RectangleShape2D_hael8")
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+&"": SubResource("AnimationLibrary_h8wm0")
+}
 
 [connection signal="mouse_entered" from="Area2D" to="." method="_on_area_2d_mouse_entered"]
 [connection signal="mouse_exited" from="Area2D" to="." method="_on_area_2d_mouse_exited"]

--- a/Scripts/GA_DECK.gd
+++ b/Scripts/GA_DECK.gd
@@ -25,3 +25,4 @@ func draw_card():
 	$"../CardManager".add_child(new_card)
 	new_card.name = "Card"
 	$"../PlayerHand".add_card_to_hand(new_card)
+	new_card.get_node("AnimationPlayer").play("card_flip")


### PR DESCRIPTION
Introduced an AnimationPlayer and card flip animation to the Card scene. Updated GA_DECK.gd to play the card_flip animation when a new card is drawn, enhancing visual feedback for card draws.