### PR TITLE
Add MAT_DECK scene and script with deck view UI

### DIFF
--- a/Scenes/Main.tscn
+++ b/Scenes/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=28 format=3 uid="uid://dqt16mao7lo7t"]
+[gd_scene load_steps=30 format=3 uid="uid://dqt16mao7lo7t"]
 
 [ext_resource type="Script" uid="uid://btk4g07uwv3gi" path="res://Scripts/CardManager.gd" id="1_uu6xs"]
 [ext_resource type="PackedScene" uid="uid://ml3qhw1idgmk" path="res://Scenes/CardsSlotForSingleCard.tscn" id="4_fos0i"]
@@ -27,6 +27,8 @@
 [ext_resource type="PackedScene" uid="uid://htnh4dr1pgp7" path="res://Scenes/Tera.tscn" id="24_3tgeq"]
 [ext_resource type="PackedScene" uid="uid://8t1wk8td74mg" path="res://Scenes/Neos.tscn" id="25_c4ay3"]
 [ext_resource type="PackedScene" uid="uid://cagxgk4egqvqv" path="res://Scenes/Luxem.tscn" id="26_aht7i"]
+[ext_resource type="PackedScene" uid="uid://drxl81ccnmul4" path="res://Scenes/mat_deck.tscn" id="28_kpo4j"]
+[ext_resource type="Script" uid="uid://o72rawju557" path="res://Scripts/MAT_DECK.gd" id="29_4n42c"]
 
 [node name="Main" type="Node2D"]
 
@@ -55,17 +57,17 @@ position = Vector2(960, 541)
 texture = ExtResource("10_bmxlf")
 
 [node name="GA_DECK" parent="." instance=ExtResource("10_4kpch")]
-position = Vector2(1360.5, 780)
+position = Vector2(1360.5, 780.5)
 scale = Vector2(0.192, 0.192)
 script = ExtResource("5_grg3l")
+
+[node name="MAT_DECK" parent="." instance=ExtResource("28_kpo4j")]
+position = Vector2(599, 780.5)
+script = ExtResource("29_4n42c")
 
 [node name="GRAVEYARD" parent="." instance=ExtResource("4_fos0i")]
 position = Vector2(1362.7, 938.3)
 scale = Vector2(0.977783, 0.974084)
-
-[node name="MAT_ DECK" parent="." instance=ExtResource("4_fos0i")]
-position = Vector2(599, 780.5)
-scale = Vector2(0.972429, 0.971529)
 
 [node name="BANISH" parent="." instance=ExtResource("5_3dxm6")]
 position = Vector2(1342, 642)

--- a/Scenes/ga_deck.tscn
+++ b/Scenes/ga_deck.tscn
@@ -16,3 +16,20 @@ collision_mask = 4
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
 shape = SubResource("RectangleShape2D_bas7d")
+
+[node name="PopupMenu" type="PopupMenu" parent="."]
+size = Vector2i(100, 50)
+
+[node name="DeckViewWindow" type="Window" parent="."]
+size = Vector2i(600, 190)
+visible = false
+unresizable = true
+
+[node name="ScrollContainer" type="ScrollContainer" parent="DeckViewWindow"]
+offset_right = 600.0
+offset_bottom = 190.0
+
+[node name="GridContainer" type="GridContainer" parent="DeckViewWindow/ScrollContainer"]
+custom_minimum_size = Vector2(600, 190)
+layout_mode = 2
+columns = 1024

--- a/Scenes/mat_deck.tscn
+++ b/Scenes/mat_deck.tscn
@@ -1,0 +1,36 @@
+[gd_scene load_steps=3 format=3 uid="uid://drxl81ccnmul4"]
+
+[ext_resource type="Texture2D" uid="uid://yaxuiipbxmdg" path="res://Assets/Grand Archive/ga_back.png" id="1_61nlp"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_4n42c"]
+size = Vector2(500, 700)
+
+[node name="MAT_DECK" type="Node2D"]
+scale = Vector2(0.192, 0.192)
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = ExtResource("1_61nlp")
+
+[node name="Area2D" type="Area2D" parent="."]
+collision_layer = 16
+collision_mask = 16
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
+shape = SubResource("RectangleShape2D_4n42c")
+
+[node name="PopupMenu" type="PopupMenu" parent="."]
+size = Vector2i(100, 50)
+
+[node name="MAT_DECK_VIEW_WINDOW" type="Window" parent="."]
+size = Vector2i(600, 190)
+visible = false
+unresizable = true
+
+[node name="ScrollContainer" type="ScrollContainer" parent="MAT_DECK_VIEW_WINDOW"]
+offset_right = 600.0
+offset_bottom = 190.0
+
+[node name="GridContainer" type="GridContainer" parent="MAT_DECK_VIEW_WINDOW/ScrollContainer"]
+custom_minimum_size = Vector2(600, 190)
+layout_mode = 2
+columns = 1024

--- a/Scripts/MAT_DECK.gd
+++ b/Scripts/MAT_DECK.gd
@@ -7,8 +7,8 @@ var card_database_reference
 const CARD_SCENE_PATH = "res://Scenes/Card.tscn"
 
 @onready var context_menu = $PopupMenu
-@onready var deck_view_window = $DeckViewWindow
-@onready var grid_container = $DeckViewWindow/ScrollContainer/GridContainer
+@onready var deck_view_window = $MAT_DECK_VIEW_WINDOW
+@onready var grid_container = $MAT_DECK_VIEW_WINDOW/ScrollContainer/GridContainer
 
 func _ready() -> void:
 	player_deck.shuffle()
@@ -76,28 +76,3 @@ func _on_deck_view_close():
 func shuffle_deck():
 	player_deck.shuffle()
 	update_deck_view()
-
-func draw_card():
-	if player_deck.size() == 0:
-		return
-	var card_drawn_name = player_deck[0]
-	player_deck.erase(card_drawn_name)
-	update_deck_view()
-	if player_deck.size() == 0:
-		$Area2D/CollisionShape2D.disabled = true
-		$Sprite2D.visible = false
-	var card_scene = preload(CARD_SCENE_PATH)
-	var new_card = card_scene.instantiate()
-	var card_image_path = "res://Assets/Grand Archive/Card Images/" + card_drawn_name + ".png"
-	if ResourceLoader.exists(card_image_path):
-		new_card.get_node("CardImage").texture = load(card_image_path)
-	new_card.set_meta("slug", card_drawn_name)
-	var unique_name = card_drawn_name
-	var counter = 2
-	while $"../CardManager".has_node(unique_name):
-		unique_name = "%s (%d)" % [card_drawn_name, counter]
-		counter += 1
-	new_card.name = unique_name
-	$"../CardManager".add_child(new_card)
-	$"../PlayerHand".add_card_to_hand(new_card)
-	new_card.get_node("AnimationPlayer").play("card_flip")


### PR DESCRIPTION
Introduces the MAT_DECK scene and MAT_DECK.gd script, mirroring GA_DECK functionality with context menu and deck viewing window. Updates Main.tscn to use the new MAT_DECK node and removes the old placeholder. Enhances GA_DECK.gd to support deck viewing and shuffling via a popup menu, and adds deck view UI elements to both deck scenes.