### PR TITLE
Add Logo scene and script, update card slot logic

### DIFF
--- a/Scenes/Logo.tscn
+++ b/Scenes/Logo.tscn
@@ -1,0 +1,14 @@
+[gd_scene format=3 uid="uid://c3x07o1r7glog"]
+
+[node name="Logo" type="Node2D"]
+
+[node name="Area2D" type="Area2D" parent="."]
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Area2D"]
+position = Vector2(648.162, 962.881)
+scale = Vector2(5.24897, 1.67304)
+polygon = PackedVector2Array(-11.6523, -22.642, -10.6997, -19.0557, -4.9843, -13.6763, -3.6507, -14.8717, -4.03173, -6.50372, -1.55505, 7.84143, -2.88865, 13.8186, -5.74635, 16.8071, -10.6997, 13.2209, -11.6523, 19.7957, -12.7954, 13.2209, -17.5582, 16.8071, -20.4159, 13.2209, -21.7495, 7.84143, -19.4633, -5.30829, -19.6539, -14.8717, -18.3203, -13.6763, -12.9859, -19.0557)
+
+[node name="PopupMenu" type="PopupMenu" parent="."]
+auto_translate_mode = 1
+size = Vector2i(100, 50)

--- a/Scenes/Main.tscn
+++ b/Scenes/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=30 format=3 uid="uid://dqt16mao7lo7t"]
+[gd_scene load_steps=32 format=3 uid="uid://dqt16mao7lo7t"]
 
 [ext_resource type="Script" uid="uid://btk4g07uwv3gi" path="res://Scripts/CardManager.gd" id="1_uu6xs"]
 [ext_resource type="PackedScene" uid="uid://ml3qhw1idgmk" path="res://Scenes/CardsSlotForSingleCard.tscn" id="4_fos0i"]
@@ -29,6 +29,8 @@
 [ext_resource type="PackedScene" uid="uid://cagxgk4egqvqv" path="res://Scenes/Luxem.tscn" id="26_aht7i"]
 [ext_resource type="PackedScene" uid="uid://drxl81ccnmul4" path="res://Scenes/mat_deck.tscn" id="28_kpo4j"]
 [ext_resource type="Script" uid="uid://o72rawju557" path="res://Scripts/MAT_DECK.gd" id="29_4n42c"]
+[ext_resource type="PackedScene" uid="uid://c3x07o1r7glog" path="res://Scenes/Logo.tscn" id="30_c5snn"]
+[ext_resource type="Script" uid="uid://dqf5rgxwib1bk" path="res://Scripts/Logo.gd" id="31_xvtyr"]
 
 [node name="Main" type="Node2D"]
 
@@ -134,3 +136,6 @@ script = ExtResource("16_5jffn")
 [node name="Luxem" parent="." instance=ExtResource("26_aht7i")]
 position = Vector2(630, 650)
 script = ExtResource("16_5jffn")
+
+[node name="Logo" parent="." instance=ExtResource("30_c5snn")]
+script = ExtResource("31_xvtyr")

--- a/Scripts/90DegreesCardSlot.gd
+++ b/Scripts/90DegreesCardSlot.gd
@@ -19,8 +19,8 @@ func update_deck_view():
 	for child in grid_container.get_children():
 		child.queue_free()
 	for card in cards_in_banish:
-		var card_name = card.card_name if card.has_method("card_name") else card.name
-		var card_display = create_card_display(card_name)
+		var card_slug = card.get_meta("slug") if card.has_meta("slug") else (card.card_name if card.has_method("card_name") else card.name)
+		var card_display = create_card_display(card_slug)
 		grid_container.add_child(card_display)
 		grid_container.move_child(card_display, 0)
 

--- a/Scripts/CardManager.gd
+++ b/Scripts/CardManager.gd
@@ -58,6 +58,14 @@ func _process(_delta: float) -> void:
 func can_drag_card(card) -> bool:
 	if not card or not is_instance_valid(card):
 		return false
+	if card.get_parent() and (card.get_parent().is_in_group("single_card_slots") or card.get_parent().is_in_group("rotated_slots")):
+		return false
+	for slot in get_tree().get_nodes_in_group("single_card_slots"):
+		if card in slot.cards_in_graveyard:
+			return false
+	for slot in get_tree().get_nodes_in_group("rotated_slots"):
+		if card in slot.cards_in_banish:
+			return false
 	if card.has_node("Area2D/CollisionShape2D"):
 		var collision_shape = card.get_node("Area2D/CollisionShape2D")
 		if collision_shape.disabled:

--- a/Scripts/GA_DECK.gd
+++ b/Scripts/GA_DECK.gd
@@ -55,6 +55,8 @@ func show_deck_view():
 	for card_name in player_deck:
 		var card_display = create_card_display(card_name)
 		grid_container.add_child(card_display)
+	if has_node("Sprite2D"):
+		$Sprite2D.modulate = Color(1, 0, 0, 1)
 	deck_view_window.popup_centered()
 
 func create_card_display(card_name: String):
@@ -72,6 +74,8 @@ func create_card_display(card_name: String):
 
 func _on_deck_view_close():
 	deck_view_window.hide()
+	if has_node("Sprite2D"):
+		$Sprite2D.modulate = Color(1, 1, 1, 1)
 
 func shuffle_deck():
 	player_deck.shuffle()

--- a/Scripts/Logo.gd
+++ b/Scripts/Logo.gd
@@ -1,0 +1,23 @@
+extends Node2D
+
+#var player_hand_node
+#
+#func _ready():
+	#player_hand_node = get_parent().get_node("PlayerHand")
+	#
+	#if player_hand_node:
+		#print("PlayerHand намерен успешно!")
+	#
+	## Свържи Area2D сигнала
+	#if has_node("Area2D"):
+		#var area = get_node("Area2D")
+		#area.input_event.connect(_on_logo_clicked)
+		#print("Area2D свързано!")
+#
+#func _on_logo_clicked(viewport, event, shape_idx):
+	#if event is InputEventMouseButton:
+		#if event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+			#print("Логото е кликнато чрез Area2D!")
+			#if player_hand_node:
+				#player_hand_node.toggle_cards_visibility()
+				#print("Картите са toggle-нати!")

--- a/Scripts/PlayerHand.gd
+++ b/Scripts/PlayerHand.gd
@@ -275,3 +275,18 @@ func cleanup():
 	player_hand.clear()
 	active_tweens = 0
 	animation_in_progress = false
+
+#func hide_all_cards():
+	#for card in player_hand:
+		#if card and is_instance_valid(card):
+			#card.visible = false
+#
+#func show_all_cards():
+	#for card in player_hand:
+		#if card and is_instance_valid(card):
+			#card.visible = true
+#
+#func toggle_cards_visibility():
+	#for card in player_hand:
+		#if card and is_instance_valid(card):
+			#card.visible = !card.visible

--- a/Scripts/SingleCardSlot.gd
+++ b/Scripts/SingleCardSlot.gd
@@ -19,8 +19,8 @@ func update_deck_view():
 	for child in grid_container.get_children():
 		child.queue_free()
 	for card in cards_in_graveyard:
-		var card_name = card.card_name if card.has_method("card_name") else card.name
-		var card_display = create_card_display(card_name)
+		var card_slug = card.get_meta("slug") if card.has_meta("slug") else (card.card_name if card.has_method("card_name") else card.name)
+		var card_display = create_card_display(card_slug)
 		grid_container.add_child(card_display)
 		grid_container.move_child(card_display, 0)
 


### PR DESCRIPTION
Introduces a new Logo scene and Logo.gd script, and integrates the Logo node into Main.tscn. Updates card display logic in 90DegreesCardSlot.gd and SingleCardSlot.gd to use card slugs if available. Enhances CardManager.gd to restrict card dragging from certain slots. GA_DECK.gd now visually indicates deck view state by modulating Sprite2D color. Adds commented-out card visibility functions in PlayerHand.gd for future use.