### PR TITLE
Refactor card display to use CardDisplay scene

### DIFF
--- a/Scenes/90DegreesCardSlot.tscn
+++ b/Scenes/90DegreesCardSlot.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://bibopkgjli11i"]
+[gd_scene load_steps=4 format=3 uid="uid://bibopkgjli11i"]
 
 [ext_resource type="Script" uid="uid://wnj3l1f3q2kj" path="res://Scripts/90DegreesCardSlot.gd" id="1_xluvn"]
+[ext_resource type="PackedScene" uid="uid://bjmf6g1notrh7" path="res://Scenes/CardDisplay.tscn" id="2_a4jdq"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_cm0pq"]
 size = Vector2(128, 90)
@@ -19,15 +20,21 @@ shape = SubResource("RectangleShape2D_cm0pq")
 size = Vector2i(100, 50)
 
 [node name="BanishViewWindow" type="Window" parent="."]
-size = Vector2i(600, 190)
+size = Vector2i(600, 142)
 visible = false
 unresizable = true
 
+[node name="PopupMenu" type="PopupMenu" parent="BanishViewWindow"]
+size = Vector2i(100, 50)
+
 [node name="ScrollContainer" type="ScrollContainer" parent="BanishViewWindow"]
 offset_right = 600.0
-offset_bottom = 190.0
+offset_bottom = 142.0
 
 [node name="GridContainer" type="GridContainer" parent="BanishViewWindow/ScrollContainer"]
-custom_minimum_size = Vector2(600, 190)
+custom_minimum_size = Vector2(600, 142)
 layout_mode = 2
 columns = 1024
+
+[node name="Control" parent="BanishViewWindow/ScrollContainer/GridContainer" instance=ExtResource("2_a4jdq")]
+layout_mode = 2

--- a/Scenes/CardDisplay.tscn
+++ b/Scenes/CardDisplay.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=2 format=3 uid="uid://bjmf6g1notrh7"]
+
+[ext_resource type="Script" uid="uid://bkfty1dvgnjap" path="res://Scripts/CardDisplay.gd" id="1_bcrn8"]
+
+[node name="Control" type="Control"]
+layout_mode = 3
+anchors_preset = 0
+script = ExtResource("1_bcrn8")
+
+[node name="TextureRect" type="TextureRect" parent="."]
+layout_mode = 0
+offset_right = 40.0
+offset_bottom = 40.0
+scale = Vector2(0.192, 0.192)

--- a/Scenes/CardsSlotForSingleCard.tscn
+++ b/Scenes/CardsSlotForSingleCard.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://ml3qhw1idgmk"]
+[gd_scene load_steps=4 format=3 uid="uid://ml3qhw1idgmk"]
 
 [ext_resource type="Script" uid="uid://c1i30tld7hk0l" path="res://Scripts/SingleCardSlot.gd" id="1_yk7di"]
+[ext_resource type="PackedScene" uid="uid://bjmf6g1notrh7" path="res://Scenes/CardDisplay.tscn" id="2_4tah1"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_3muqk"]
 size = Vector2(92, 132)
@@ -19,15 +20,21 @@ shape = SubResource("RectangleShape2D_3muqk")
 size = Vector2i(100, 50)
 
 [node name="GraveyardViewWindow" type="Window" parent="."]
-size = Vector2i(600, 190)
+size = Vector2i(600, 142)
 visible = false
 unresizable = true
 
+[node name="PopupMenu" type="PopupMenu" parent="GraveyardViewWindow"]
+size = Vector2i(100, 50)
+
 [node name="ScrollContainer" type="ScrollContainer" parent="GraveyardViewWindow"]
 offset_right = 600.0
-offset_bottom = 190.0
+offset_bottom = 142.0
 
 [node name="GridContainer" type="GridContainer" parent="GraveyardViewWindow/ScrollContainer"]
-custom_minimum_size = Vector2(600, 190)
+custom_minimum_size = Vector2(600, 142)
 layout_mode = 2
 columns = 1024
+
+[node name="Control" parent="GraveyardViewWindow/ScrollContainer/GridContainer" instance=ExtResource("2_4tah1")]
+layout_mode = 2

--- a/Scenes/ga_deck.tscn
+++ b/Scenes/ga_deck.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://bhhjuuiiuqcoi"]
+[gd_scene load_steps=4 format=3 uid="uid://bhhjuuiiuqcoi"]
 
 [ext_resource type="Texture2D" uid="uid://yaxuiipbxmdg" path="res://Assets/Grand Archive/ga_back.png" id="1_8vpbr"]
+[ext_resource type="PackedScene" uid="uid://bjmf6g1notrh7" path="res://Scenes/CardDisplay.tscn" id="2_yhn4k"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_bas7d"]
 size = Vector2(500, 700)
@@ -21,15 +22,21 @@ shape = SubResource("RectangleShape2D_bas7d")
 size = Vector2i(100, 50)
 
 [node name="DeckViewWindow" type="Window" parent="."]
-size = Vector2i(600, 190)
+size = Vector2i(600, 142)
 visible = false
 unresizable = true
 
+[node name="PopupMenu" type="PopupMenu" parent="DeckViewWindow"]
+size = Vector2i(100, 50)
+
 [node name="ScrollContainer" type="ScrollContainer" parent="DeckViewWindow"]
 offset_right = 600.0
-offset_bottom = 190.0
+offset_bottom = 142.0
 
 [node name="GridContainer" type="GridContainer" parent="DeckViewWindow/ScrollContainer"]
-custom_minimum_size = Vector2(600, 190)
+custom_minimum_size = Vector2(600, 142)
 layout_mode = 2
 columns = 1024
+
+[node name="Control" parent="DeckViewWindow/ScrollContainer/GridContainer" instance=ExtResource("2_yhn4k")]
+layout_mode = 2

--- a/Scenes/mat_deck.tscn
+++ b/Scenes/mat_deck.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://drxl81ccnmul4"]
+[gd_scene load_steps=4 format=3 uid="uid://drxl81ccnmul4"]
 
 [ext_resource type="Texture2D" uid="uid://yaxuiipbxmdg" path="res://Assets/Grand Archive/ga_back.png" id="1_61nlp"]
+[ext_resource type="PackedScene" uid="uid://bjmf6g1notrh7" path="res://Scenes/CardDisplay.tscn" id="2_5xpqa"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_4n42c"]
 size = Vector2(500, 700)
@@ -22,15 +23,21 @@ shape = SubResource("RectangleShape2D_4n42c")
 size = Vector2i(100, 50)
 
 [node name="MAT_DECK_VIEW_WINDOW" type="Window" parent="."]
-size = Vector2i(600, 190)
+size = Vector2i(600, 142)
 visible = false
 unresizable = true
 
+[node name="PopupMenu" type="PopupMenu" parent="MAT_DECK_VIEW_WINDOW"]
+size = Vector2i(100, 50)
+
 [node name="ScrollContainer" type="ScrollContainer" parent="MAT_DECK_VIEW_WINDOW"]
 offset_right = 600.0
-offset_bottom = 190.0
+offset_bottom = 142.0
 
 [node name="GridContainer" type="GridContainer" parent="MAT_DECK_VIEW_WINDOW/ScrollContainer"]
-custom_minimum_size = Vector2(600, 190)
+custom_minimum_size = Vector2(600, 142)
 layout_mode = 2
 columns = 1024
+
+[node name="Control" parent="MAT_DECK_VIEW_WINDOW/ScrollContainer/GridContainer" instance=ExtResource("2_5xpqa")]
+layout_mode = 2

--- a/Scripts/90DegreesCardSlot.gd
+++ b/Scripts/90DegreesCardSlot.gd
@@ -47,27 +47,25 @@ func view_deck():
 	show_deck_view()
 
 func create_card_display(card_name: String):
-	var card_control = Control.new()
-	card_control.custom_minimum_size = Vector2(125, 180)
-	var texture_rect = TextureRect.new()
-	texture_rect.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	texture_rect.expand_mode = TextureRect.EXPAND_FIT_WIDTH_PROPORTIONAL
-	texture_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
-	var card_image_path = "res://Assets/Grand Archive/Card Images/" + card_name + ".png"
-	if ResourceLoader.exists(card_image_path):
-		texture_rect.texture = load(card_image_path)
-	else:
-		var label = Label.new()
-		label.text = card_name
-		label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-		label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
-		card_control.add_child(label)
-	card_control.add_child(texture_rect)
-	return card_control
+	var card_display_scene = preload("res://Scenes/CardDisplay.tscn")
+	var card_display = card_display_scene.instantiate()
+	card_display.set_meta("slug", card_name)
+	card_display.set_meta("zone", "banish")
+	card_display.request_popup_menu.connect(_on_card_display_popup_menu)
+	return card_display
+
+func _on_card_display_popup_menu(slug):
+	var popup_menu = $BanishViewWindow/PopupMenu
+	popup_menu.clear()
+	popup_menu.add_item("test3")
+	popup_menu.add_item("test4")
+	popup_menu.popup(Rect2(get_viewport().get_mouse_position(), Vector2(0, 0)))
 
 func show_deck_view():
 	update_deck_view()
 	banish_view_window.popup_centered()
+	$BanishViewWindow/ScrollContainer.call_deferred("set", "scroll_horizontal", 0)
+	$BanishViewWindow/ScrollContainer.call_deferred("set", "scroll_vertical", 0)
 
 func _on_deck_view_close():
 	banish_view_window.hide()

--- a/Scripts/Card.gd
+++ b/Scripts/Card.gd
@@ -6,7 +6,8 @@ signal hovered_off
 var hand_position
 
 func _ready() -> void:
-	get_parent().connect_card_signals(self)
+	if get_parent() and get_parent().has_method("connect_card_signals"):
+		get_parent().connect_card_signals(self)
 
 func _on_area_2d_mouse_entered() -> void:
 	emit_signal("hovered", self)

--- a/Scripts/CardDisplay.gd
+++ b/Scripts/CardDisplay.gd
@@ -1,0 +1,62 @@
+extends Control
+
+var card_slug = ""
+var card_image_path = ""
+var zone = ""
+
+signal request_popup_menu(slug)
+
+@onready var texture_rect = $TextureRect
+
+const CARD_DISPLAY_SIZE = Vector2(98, 98)
+
+func _ready():
+	if has_meta("zone"):
+		zone = get_meta("zone")
+	else:
+		zone = ""
+	size_flags_horizontal = Control.SIZE_SHRINK_CENTER
+	size_flags_vertical = Control.SIZE_SHRINK_CENTER
+	custom_minimum_size = CARD_DISPLAY_SIZE
+	texture_rect.size_flags_horizontal = Control.SIZE_SHRINK_CENTER
+	texture_rect.size_flags_vertical = Control.SIZE_SHRINK_CENTER
+	texture_rect.custom_minimum_size = CARD_DISPLAY_SIZE
+	texture_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	if has_meta("slug"):
+		card_slug = get_meta("slug")
+	if card_slug != "":
+		card_image_path = "res://Assets/Grand Archive/Card Images/" + card_slug + ".png"
+	if card_image_path != "" and ResourceLoader.exists(card_image_path):
+		texture_rect.texture = load(card_image_path)
+		texture_rect.size = CARD_DISPLAY_SIZE
+	mouse_entered.connect(_on_mouse_entered)
+	mouse_exited.connect(_on_mouse_exited)
+
+func _on_mouse_entered():
+	self.scale = Vector2(1, 1)
+	self.z_index = 100
+	var card_info_node = get_tree().get_current_scene().get_node_or_null("CardInformation")
+	if card_info_node and card_info_node.has_method("show_card_info"):
+		card_info_node.show_card_info(card_slug)
+
+func _on_mouse_exited():
+	self.scale = Vector2(1, 1)
+	self.z_index = 0
+
+func _gui_input(event):
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+		if zone in ["graveyard", "banish", "ga_deck", "mat_deck"]:
+			emit_signal("request_popup_menu", card_slug)
+
+func get_drag_data(_pos):
+	set_drag_preview(texture_rect.duplicate())
+	return card_slug
+
+func can_drop_data(_pos, data):
+	return typeof(data) == TYPE_STRING and data != card_slug
+
+func drop_data(_pos, data):
+	card_slug = data
+	card_image_path = "res://Assets/Grand Archive/Card Images/" + card_slug + ".png"
+	if ResourceLoader.exists(card_image_path):
+		texture_rect.texture = load(card_image_path)

--- a/Scripts/CardInformation.gd
+++ b/Scripts/CardInformation.gd
@@ -62,6 +62,10 @@ func show_card_info(slug: String):
 		return
 	card_name_label.clear()
 	card_effect_lable.clear()
+	if preview_sprite and slug != "":
+		var card_image_path = "res://Assets/Grand Archive/Card Images/" + slug + ".png"
+		if ResourceLoader.exists(card_image_path):
+			preview_sprite.texture = load(card_image_path)
 	var name_to_display = ""
 	var effect_to_display = ""
 	if card_database_reference and card_database_reference.cards_db.has(slug):
@@ -84,7 +88,6 @@ func show_card_info(slug: String):
 	if name_to_display != "":
 		var cleaned_name = fix_weird_quotes_and_dashes(name_to_display.strip_edges())
 		card_name_label.append_text("[center][b]%s[/b][/center]" % cleaned_name)
-
 	if effect_to_display != "":
 		var cleaned_effect = fix_weird_quotes_and_dashes(effect_to_display.strip_edges())
 		card_effect_lable.append_text(cleaned_effect)

--- a/Scripts/GA_DECK.gd
+++ b/Scripts/GA_DECK.gd
@@ -48,29 +48,30 @@ func update_deck_view():
 	for card_name in player_deck:
 		var card_display = create_card_display(card_name)
 		grid_container.add_child(card_display)
+	grid_container.call_deferred("queue_sort")
 
 func show_deck_view():
-	update_deck_view()
 	deck_view_window.popup_centered()
-	for card_name in player_deck:
-		var card_display = create_card_display(card_name)
-		grid_container.add_child(card_display)
+	update_deck_view()
+	$DeckViewWindow/ScrollContainer.call_deferred("set", "scroll_horizontal", 0)
+	$DeckViewWindow/ScrollContainer.call_deferred("set", "scroll_vertical", 0)
 	if has_node("Sprite2D"):
 		$Sprite2D.modulate = Color(1, 0, 0, 1)
-	deck_view_window.popup_centered()
 
 func create_card_display(card_name: String):
-	var card_control = Control.new()
-	card_control.custom_minimum_size = Vector2(125, 180)
-	var texture_rect = TextureRect.new()
-	texture_rect.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	texture_rect.expand_mode = TextureRect.EXPAND_FIT_WIDTH_PROPORTIONAL
-	texture_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
-	var card_image_path = "res://Assets/Grand Archive/Card Images/" + card_name + ".png"
-	if ResourceLoader.exists(card_image_path):
-		texture_rect.texture = load(card_image_path)
-	card_control.add_child(texture_rect)
-	return card_control
+	var card_display_scene = preload("res://Scenes/CardDisplay.tscn")
+	var card_display = card_display_scene.instantiate()
+	card_display.set_meta("slug", card_name)
+	card_display.set_meta("zone", "ga_deck")
+	card_display.request_popup_menu.connect(_on_card_display_popup_menu)
+	return card_display
+
+func _on_card_display_popup_menu(slug):
+	var popup_menu = $DeckViewWindow/PopupMenu
+	popup_menu.clear()
+	popup_menu.add_item("test5")
+	popup_menu.add_item("test6")
+	popup_menu.popup(Rect2(get_viewport().get_mouse_position(), Vector2(0, 0)))
 
 func _on_deck_view_close():
 	deck_view_window.hide()

--- a/Scripts/Logo.gd
+++ b/Scripts/Logo.gd
@@ -13,7 +13,7 @@ func find_node_recursive(node, target_name):
 			return found
 	return null
 
-func _on_Area2D_input_event(viewport, event, shape_idx):
+func _on_Area2D_input_event(viewport, event, _shape_idx):
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
 		var player_hand_node = find_node_recursive(get_tree().get_root(), "PlayerHand")
 		if player_hand_node:

--- a/Scripts/MAT_DECK.gd
+++ b/Scripts/MAT_DECK.gd
@@ -50,25 +50,25 @@ func update_deck_view():
 		grid_container.add_child(card_display)
 
 func show_deck_view():
+	deck_view_window.popup_centered()
 	update_deck_view()
-	deck_view_window.popup_centered()
-	for card_name in player_deck:
-		var card_display = create_card_display(card_name)
-		grid_container.add_child(card_display)
-	deck_view_window.popup_centered()
+	$MAT_DECK_VIEW_WINDOW/ScrollContainer.call_deferred("set", "scroll_horizontal", 0)
+	$MAT_DECK_VIEW_WINDOW/ScrollContainer.call_deferred("set", "scroll_vertical", 0)
 
 func create_card_display(card_name: String):
-	var card_control = Control.new()
-	card_control.custom_minimum_size = Vector2(125, 180)
-	var texture_rect = TextureRect.new()
-	texture_rect.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	texture_rect.expand_mode = TextureRect.EXPAND_FIT_WIDTH_PROPORTIONAL
-	texture_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
-	var card_image_path = "res://Assets/Grand Archive/Card Images/" + card_name + ".png"
-	if ResourceLoader.exists(card_image_path):
-		texture_rect.texture = load(card_image_path)
-	card_control.add_child(texture_rect)
-	return card_control
+	var card_display_scene = preload("res://Scenes/CardDisplay.tscn")
+	var card_display = card_display_scene.instantiate()
+	card_display.set_meta("slug", card_name)
+	card_display.set_meta("zone", "mat_deck")
+	card_display.request_popup_menu.connect(_on_card_display_popup_menu)
+	return card_display
+
+func _on_card_display_popup_menu(slug):
+	var popup_menu = $MAT_DECK_VIEW_WINDOW/PopupMenu
+	popup_menu.clear()
+	popup_menu.add_item("test7")
+	popup_menu.add_item("test8")
+	popup_menu.popup(Rect2(get_viewport().get_mouse_position(), Vector2(0, 0)))
 
 func _on_deck_view_close():
 	deck_view_window.hide()

--- a/Scripts/Main_Field.gd
+++ b/Scripts/Main_Field.gd
@@ -10,12 +10,9 @@ func _ready() -> void:
 
 func add_card_to_field(card, position = null):
 	if position == null:
-		# Първата карта отива в центъра на Main_Field
 		card.global_position = global_position
 	else:
-		# Останалите карти отиват там където са поставени
 		card.global_position = position
-	
 	cards_in_field.append(card)
 	card_in_slot = true
 
@@ -36,7 +33,7 @@ func bring_card_to_front(card):
 		var current_card = cards_in_field[i]
 		if current_card and is_instance_valid(current_card):
 			if i >= card_index:
-				current_card.z_index = 200 + i + 50  # По-висок от ръката
+				current_card.z_index = 200 + i + 50
 			else:
 				current_card.z_index = 200 + i + 1
 

--- a/Scripts/SingleCardSlot.gd
+++ b/Scripts/SingleCardSlot.gd
@@ -47,27 +47,25 @@ func view_deck():
 	show_deck_view()
 
 func create_card_display(card_name: String):
-	var card_control = Control.new()
-	card_control.custom_minimum_size = Vector2(125, 180)
-	var texture_rect = TextureRect.new()
-	texture_rect.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	texture_rect.expand_mode = TextureRect.EXPAND_FIT_WIDTH_PROPORTIONAL
-	texture_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
-	var card_image_path = "res://Assets/Grand Archive/Card Images/" + card_name + ".png"
-	if ResourceLoader.exists(card_image_path):
-		texture_rect.texture = load(card_image_path)
-	else:
-		var label = Label.new()
-		label.text = card_name
-		label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-		label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
-		card_control.add_child(label)
-	card_control.add_child(texture_rect)
-	return card_control
+	var card_display_scene = preload("res://Scenes/CardDisplay.tscn")
+	var card_display = card_display_scene.instantiate()
+	card_display.set_meta("slug", card_name)
+	card_display.set_meta("zone", "graveyard")
+	card_display.request_popup_menu.connect(_on_card_display_popup_menu)
+	return card_display
+
+func _on_card_display_popup_menu(_slug):
+	var popup_menu = $GraveyardViewWindow/PopupMenu
+	popup_menu.clear()
+	popup_menu.add_item("test1")
+	popup_menu.add_item("test2")
+	popup_menu.popup(Rect2(get_viewport().get_mouse_position(), Vector2(0, 0)))
 
 func show_deck_view():
 	update_deck_view()
 	graveyard_view_window.popup_centered()
+	$GraveyardViewWindow/ScrollContainer.call_deferred("set", "scroll_horizontal", 0)
+	$GraveyardViewWindow/ScrollContainer.call_deferred("set", "scroll_vertical", 0)
 
 func _on_deck_view_close():
 	graveyard_view_window.hide()


### PR DESCRIPTION
Replaces manual card display creation in deck and slot scripts with a reusable CardDisplay scene and script. Adds CardDisplay.tscn and CardDisplay.gd, updates deck/slot scenes to use the new scene, and implements popup menu handling for card actions. Also improves card info preview and ensures scroll containers reset position when opening deck/slot views.