### PR TITLE
Add Phases scene and integrate into Main scene

### DIFF
--- a/Scenes/Main.tscn
+++ b/Scenes/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=32 format=3 uid="uid://dqt16mao7lo7t"]
+[gd_scene load_steps=33 format=3 uid="uid://dqt16mao7lo7t"]
 
 [ext_resource type="Script" uid="uid://btk4g07uwv3gi" path="res://Scripts/CardManager.gd" id="1_uu6xs"]
 [ext_resource type="PackedScene" uid="uid://ml3qhw1idgmk" path="res://Scenes/CardsSlotForSingleCard.tscn" id="4_fos0i"]
@@ -31,6 +31,7 @@
 [ext_resource type="Script" uid="uid://o72rawju557" path="res://Scripts/MAT_DECK.gd" id="29_4n42c"]
 [ext_resource type="PackedScene" uid="uid://c3x07o1r7glog" path="res://Scenes/Logo.tscn" id="30_c5snn"]
 [ext_resource type="Script" uid="uid://coysovnn26kgf" path="res://Scripts/Logo.gd" id="31_xvtyr"]
+[ext_resource type="PackedScene" uid="uid://cpn7rtonc8qd4" path="res://Scenes/Phases.tscn" id="32_u7mjy"]
 
 [node name="Main" type="Node2D"]
 
@@ -140,3 +141,5 @@ script = ExtResource("16_5jffn")
 [node name="Logo" parent="." instance=ExtResource("30_c5snn")]
 position = Vector2(590, 960)
 script = ExtResource("31_xvtyr")
+
+[node name="Phases" parent="." instance=ExtResource("32_u7mjy")]

--- a/Scenes/Phases.tscn
+++ b/Scenes/Phases.tscn
@@ -1,0 +1,180 @@
+[gd_scene load_steps=2 format=3 uid="uid://cpn7rtonc8qd4"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_xvtyr"]
+size = Vector2(105, 63)
+
+[node name="Phases" type="Node2D"]
+
+[node name="WakeUpArea2D" type="Area2D" parent="."]
+position = Vector2(1532.5, 66.5)
+collision_layer = 64
+collision_mask = 64
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="WakeUpArea2D"]
+shape = SubResource("RectangleShape2D_xvtyr")
+
+[node name="MaterializeArea2D" type="Area2D" parent="."]
+position = Vector2(1682.5, 66.5)
+collision_layer = 64
+collision_mask = 64
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="MaterializeArea2D"]
+shape = SubResource("RectangleShape2D_xvtyr")
+
+[node name="RecollectionArea2D" type="Area2D" parent="."]
+position = Vector2(1832.5, 66.5)
+collision_layer = 64
+collision_mask = 64
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="RecollectionArea2D"]
+shape = SubResource("RectangleShape2D_xvtyr")
+
+[node name="DrawArea2D" type="Area2D" parent="."]
+position = Vector2(1532.5, 141.5)
+collision_layer = 64
+collision_mask = 64
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="DrawArea2D"]
+shape = SubResource("RectangleShape2D_xvtyr")
+
+[node name="MainArea2D" type="Area2D" parent="."]
+position = Vector2(1682.5, 141.5)
+collision_layer = 64
+collision_mask = 64
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="MainArea2D"]
+shape = SubResource("RectangleShape2D_xvtyr")
+
+[node name="EndArea2D" type="Area2D" parent="."]
+position = Vector2(1832.5, 141.5)
+collision_layer = 64
+collision_mask = 64
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="EndArea2D"]
+shape = SubResource("RectangleShape2D_xvtyr")
+
+[node name="Wake Up Phase" type="RichTextLabel" parent="."]
+offset_left = 1474.0
+offset_top = 44.0
+offset_right = 1591.0
+offset_bottom = 90.0
+text = "Wake Up Phase"
+fit_content = true
+horizontal_alignment = 1
+
+[node name="Materialize Phase" type="RichTextLabel" parent="."]
+offset_left = 1624.0
+offset_top = 44.0
+offset_right = 1745.0
+offset_bottom = 90.0
+text = "Materialize Phase"
+fit_content = true
+horizontal_alignment = 1
+
+[node name="Recollection Phase" type="RichTextLabel" parent="."]
+offset_left = 1774.0
+offset_top = 44.0
+offset_right = 1891.0
+offset_bottom = 90.0
+text = "Recollection Phase"
+fit_content = true
+horizontal_alignment = 1
+
+[node name="Draw Phase" type="RichTextLabel" parent="."]
+offset_left = 1492.0
+offset_top = 113.0
+offset_right = 1574.0
+offset_bottom = 159.0
+text = "Draw Phase"
+fit_content = true
+horizontal_alignment = 1
+
+[node name="Main Phase" type="RichTextLabel" parent="."]
+offset_left = 1643.0
+offset_top = 113.0
+offset_right = 1726.0
+offset_bottom = 159.0
+text = "Main Phase"
+fit_content = true
+horizontal_alignment = 1
+
+[node name="End Phase" type="RichTextLabel" parent="."]
+offset_left = 1795.0
+offset_top = 113.0
+offset_right = 1870.0
+offset_bottom = 159.0
+text = "End Phase"
+fit_content = true
+horizontal_alignment = 1
+
+[node name="LineWakeUpR" type="Line2D" parent="."]
+position = Vector2(1587.57, 101.204)
+scale = Vector2(0.573752, 4.41176)
+points = PackedVector2Array(-4.48584, -15.0063, -4.48584, -0.726273)
+width = 2.0
+
+[node name="LineWakeUpL" type="Line2D" parent="."]
+position = Vector2(1482.57, 101.204)
+scale = Vector2(0.573752, 4.41176)
+points = PackedVector2Array(-4.48584, -15.0063, -4.48584, -0.726273)
+width = 2.0
+
+[node name="LineDrawR" type="Line2D" parent="."]
+position = Vector2(1587.57, 176.204)
+scale = Vector2(0.573752, 4.41176)
+points = PackedVector2Array(-4.48584, -15.0063, -4.48584, -0.726273)
+width = 2.0
+
+[node name="LineDrawL" type="Line2D" parent="."]
+position = Vector2(1482.57, 176.204)
+scale = Vector2(0.573752, 4.41176)
+points = PackedVector2Array(-4.48584, -15.0063, -4.48584, -0.726273)
+width = 2.0
+
+[node name="LineMaterializeL" type="Line2D" parent="."]
+position = Vector2(1632.57, 101.204)
+scale = Vector2(0.573752, 4.41176)
+points = PackedVector2Array(-4.48584, -15.0063, -4.48584, -0.726273)
+width = 2.0
+
+[node name="LineMaterializeR" type="Line2D" parent="."]
+position = Vector2(1737.57, 101.204)
+scale = Vector2(0.573752, 4.41176)
+points = PackedVector2Array(-4.48584, -15.0063, -4.48584, -0.726273)
+width = 2.0
+
+[node name="LineMainL" type="Line2D" parent="."]
+position = Vector2(1632.57, 176.204)
+scale = Vector2(0.573752, 4.41176)
+points = PackedVector2Array(-4.48584, -15.0063, -4.48584, -0.726273)
+width = 2.0
+
+[node name="LineMainR" type="Line2D" parent="."]
+position = Vector2(1737.57, 176.204)
+scale = Vector2(0.573752, 4.41176)
+points = PackedVector2Array(-4.48584, -15.0063, -4.48584, -0.726273)
+width = 2.0
+
+[node name="LineEndL" type="Line2D" parent="."]
+position = Vector2(1782.57, 176.204)
+scale = Vector2(0.573752, 4.41176)
+points = PackedVector2Array(-4.48584, -15.0063, -4.48584, -0.726273)
+width = 2.0
+
+[node name="LineEndR" type="Line2D" parent="."]
+position = Vector2(1887.57, 176.204)
+scale = Vector2(0.573752, 4.41176)
+points = PackedVector2Array(-4.48584, -15.0063, -4.48584, -0.726273)
+width = 2.0
+
+[node name="LineRecollectionL" type="Line2D" parent="."]
+position = Vector2(1782.57, 101.204)
+scale = Vector2(0.573752, 4.41176)
+points = PackedVector2Array(-4.48584, -15.0063, -4.48584, -0.726273)
+width = 2.0
+
+[node name="LineRecollectionR" type="Line2D" parent="."]
+position = Vector2(1887.57, 101.204)
+scale = Vector2(0.573752, 4.41176)
+points = PackedVector2Array(-4.48584, -15.0063, -4.48584, -0.726273)
+width = 2.0

--- a/Scripts/CardManager.gd
+++ b/Scripts/CardManager.gd
@@ -140,7 +140,6 @@ func finish_drag():
 			card_slot_found.add_card_to_slot(card_being_dragged)
 			card_being_dragged.scale = normal_scale
 			card_being_dragged.z_index = base_z_index
-			card_being_dragged.rotation_degrees = -90
 		else:
 			card_being_dragged.z_index = base_z_index + card_counter
 			card_counter += 1

--- a/Scripts/MemoryCardsSlot.gd
+++ b/Scripts/MemoryCardsSlot.gd
@@ -61,13 +61,13 @@ func clear_hovered_card():
 			card.z_index = memory_z_index_offset + i + 1
 
 func show_card_back(card):
+	var card_image = card.get_node_or_null("CardImage")
 	if not card or not is_instance_valid(card):
 		return
 	if not card.has_meta("original_card_texture"):
-		var card_image = card.get_node_or_null("CardImage")
+
 		if card_image and card_image.texture:
 			card.set_meta("original_card_texture", card_image.texture)
-	var card_image = card.get_node_or_null("CardImage")
 	var card_image_back = card.get_node_or_null("CardImageBack")
 	if card_image and card_image_back:
 		card_image_back.z_index = 0


### PR DESCRIPTION
Introduced a new Phases.tscn scene with labeled phase areas and visual separators. Integrated the Phases scene into Main.tscn. Also removed forced rotation reset on dragged cards in CardManager.gd and fixed variable scope in show_card_back in MemoryCardsSlot.gd.