### PR TITLE
Add Phases node and script to main scene

### DIFF
--- a/Scenes/Main.tscn
+++ b/Scenes/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=33 format=3 uid="uid://dqt16mao7lo7t"]
+[gd_scene load_steps=34 format=3 uid="uid://dqt16mao7lo7t"]
 
 [ext_resource type="Script" uid="uid://btk4g07uwv3gi" path="res://Scripts/CardManager.gd" id="1_uu6xs"]
 [ext_resource type="PackedScene" uid="uid://ml3qhw1idgmk" path="res://Scenes/CardsSlotForSingleCard.tscn" id="4_fos0i"]
@@ -32,6 +32,7 @@
 [ext_resource type="PackedScene" uid="uid://c3x07o1r7glog" path="res://Scenes/Logo.tscn" id="30_c5snn"]
 [ext_resource type="Script" uid="uid://coysovnn26kgf" path="res://Scripts/Logo.gd" id="31_xvtyr"]
 [ext_resource type="PackedScene" uid="uid://cpn7rtonc8qd4" path="res://Scenes/Phases.tscn" id="32_u7mjy"]
+[ext_resource type="Script" uid="uid://cjdv252o1hnhq" path="res://Scripts/Phases.gd" id="33_4yxf6"]
 
 [node name="Main" type="Node2D"]
 
@@ -143,3 +144,4 @@ position = Vector2(590, 960)
 script = ExtResource("31_xvtyr")
 
 [node name="Phases" parent="." instance=ExtResource("32_u7mjy")]
+script = ExtResource("33_4yxf6")

--- a/Scripts/Phases.gd
+++ b/Scripts/Phases.gd
@@ -1,0 +1,59 @@
+extends Node2D
+
+var area_line_mapping = {
+	"WakeUpArea2D": ["LineWakeUpR", "LineWakeUpL"],
+	"MaterializeArea2D": ["LineMaterializeL", "LineMaterializeR"], 
+	"RecollectionArea2D": ["LineRecollectionL", "LineRecollectionR"],
+	"DrawArea2D": ["LineDrawR", "LineDrawL"],
+	"MainArea2D": ["LineMainL", "LineMainR"],
+	"EndArea2D": ["LineEndL", "LineEndR"]
+}
+var areas = {}
+var all_lines = []
+
+func _ready():
+	collect_areas_and_lines()
+	hide_all_lines()
+	show_lines_for_area("MaterializeArea2D")
+
+func collect_areas_and_lines():
+	for area_name in area_line_mapping:
+		var area_node = get_node_or_null(area_name)
+		if area_node:
+			areas[area_name] = area_node
+	for area_name in area_line_mapping:
+		for line_name in area_line_mapping[area_name]:
+			var line_node = get_node_or_null(line_name)
+			if line_node:
+				all_lines.append(line_node)
+
+func _input(event):
+	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+		check_click_on_areas(event.position)
+
+func check_click_on_areas(click_pos: Vector2):
+	for area_name in areas:
+		var area = areas[area_name]
+		if is_point_in_area(area, click_pos):
+			show_lines_for_area(area_name)
+			break
+
+func is_point_in_area(area: Area2D, point: Vector2) -> bool:
+	var collision_shape = area.get_node("CollisionShape2D")
+	if not collision_shape or not collision_shape.shape:
+		return false
+	var local_point = area.to_local(point)
+	return collision_shape.shape.get_rect().has_point(local_point)
+
+func show_lines_for_area(area_name: String):
+	hide_all_lines()
+	if area_name in area_line_mapping:
+		for line_name in area_line_mapping[area_name]:
+			var line_node = get_node_or_null(line_name)
+			if line_node:
+				line_node.visible = true
+
+func hide_all_lines():
+	for line in all_lines:
+		if line and is_instance_valid(line):
+			line.visible = false


### PR DESCRIPTION
Introduces a new Phases.gd script and attaches it to the Phases node in Main.tscn. The script manages area-to-line mapping, handles mouse input to highlight lines for the selected phase, and improves scene interactivity.