### PR TITLE
Add opponent deck and mat to main scene

### DIFF
--- a/Scenes/Main.tscn
+++ b/Scenes/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=34 format=3 uid="uid://dqt16mao7lo7t"]
+[gd_scene load_steps=35 format=3 uid="uid://dqt16mao7lo7t"]
 
 [ext_resource type="Script" uid="uid://btk4g07uwv3gi" path="res://Scripts/CardManager.gd" id="1_uu6xs"]
 [ext_resource type="PackedScene" uid="uid://ml3qhw1idgmk" path="res://Scenes/CardsSlotForSingleCard.tscn" id="4_fos0i"]
@@ -18,6 +18,7 @@
 [ext_resource type="PackedScene" uid="uid://d2q27vj536tlk" path="res://Scenes/Fire.tscn" id="16_2w5on"]
 [ext_resource type="Script" uid="uid://c57bimiwmr0yp" path="res://Scripts/Element.gd" id="16_5jffn"]
 [ext_resource type="PackedScene" uid="uid://cxd2mvn6wykfl" path="res://Scenes/Water.tscn" id="17_346fj"]
+[ext_resource type="Texture2D" uid="uid://yaxuiipbxmdg" path="res://Assets/Grand Archive/ga_back.png" id="17_qta6b"]
 [ext_resource type="PackedScene" uid="uid://8bexacpcoqme" path="res://Scenes/Wind.tscn" id="18_0sclb"]
 [ext_resource type="PackedScene" uid="uid://dykyungnxlstu" path="res://Scenes/Astra.tscn" id="19_sxkr1"]
 [ext_resource type="PackedScene" uid="uid://d1fe3gik6qku8" path="res://Scenes/Umbra.tscn" id="20_hwpts"]
@@ -48,7 +49,7 @@ position = Vector2(980, 800)
 scale = Vector2(0.474, 0.474)
 texture = ExtResource("5_fos0i")
 
-[node name="FieldGa2" type="Sprite2D" parent="GAField"]
+[node name="FieldGaOpponent" type="Sprite2D" parent="GAField"]
 z_index = -1
 position = Vector2(980, 280)
 rotation = -3.14159
@@ -91,6 +92,26 @@ script = ExtResource("7_lgr22")
 script = ExtResource("13_frkhe")
 
 [node name="CardInformation" parent="." instance=ExtResource("14_1p5hy")]
+
+[node name="OpponentDeck" type="Node2D" parent="."]
+
+[node name="Sprite2D" type="Sprite2D" parent="OpponentDeck"]
+position = Vector2(599.5, 300)
+rotation = 3.14159
+scale = Vector2(0.192, 0.192)
+texture = ExtResource("17_qta6b")
+
+[node name="OpponentMatDeck" type="Node2D" parent="."]
+
+[node name="Sprite2D" type="Sprite2D" parent="OpponentMatDeck"]
+position = Vector2(1361, 300)
+rotation = 3.14159
+scale = Vector2(0.192, 0.192)
+texture = ExtResource("17_qta6b")
+
+[node name="OpponentBanish" type="Node2D" parent="."]
+
+[node name="OpponentGraveyard" type="Node2D" parent="."]
 
 [node name="Norm" parent="." instance=ExtResource("15_h1m7h")]
 position = Vector2(560, 580)

--- a/Scripts/90DegreesCardSlot.gd
+++ b/Scripts/90DegreesCardSlot.gd
@@ -54,7 +54,7 @@ func create_card_display(card_name: String):
 	card_display.request_popup_menu.connect(_on_card_display_popup_menu)
 	return card_display
 
-func _on_card_display_popup_menu(slug):
+func _on_card_display_popup_menu(_slug):
 	var popup_menu = $BanishViewWindow/PopupMenu
 	popup_menu.clear()
 	popup_menu.add_item("test3")
@@ -90,8 +90,8 @@ func remove_card_from_slot(card):
 func get_top_card():
 	return null
 
-func bring_card_to_front(card):
-	pass
-
-func clear_hovered_card():
-	pass
+#func bring_card_to_front(card):
+	#pass
+#
+#func clear_hovered_card():
+	#pass

--- a/Scripts/GA_DECK.gd
+++ b/Scripts/GA_DECK.gd
@@ -66,7 +66,7 @@ func create_card_display(card_name: String):
 	card_display.request_popup_menu.connect(_on_card_display_popup_menu)
 	return card_display
 
-func _on_card_display_popup_menu(slug):
+func _on_card_display_popup_menu(_slug):
 	var popup_menu = $DeckViewWindow/PopupMenu
 	popup_menu.clear()
 	popup_menu.add_item("test5")

--- a/Scripts/Logo.gd
+++ b/Scripts/Logo.gd
@@ -19,7 +19,7 @@ func find_node_recursive(node, target_name):
 			return found
 	return null
 
-func _on_Area2D_input_event(viewport, event, _shape_idx):
+func _on_Area2D_input_event(_viewport, event, _shape_idx):
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
 		var player_hand_node = find_node_recursive(get_tree().get_root(), "PlayerHand")
 		if player_hand_node:

--- a/Scripts/MAT_DECK.gd
+++ b/Scripts/MAT_DECK.gd
@@ -61,7 +61,7 @@ func create_card_display(card_name: String):
 	card_display.request_popup_menu.connect(_on_card_display_popup_menu)
 	return card_display
 
-func _on_card_display_popup_menu(slug):
+func _on_card_display_popup_menu(_slug):
 	var popup_menu = $MAT_DECK_VIEW_WINDOW/PopupMenu
 	popup_menu.clear()
 	popup_menu.add_item("test7")

--- a/Scripts/MemoryCardsSlot.gd
+++ b/Scripts/MemoryCardsSlot.gd
@@ -1,6 +1,7 @@
 extends Node2D
 
 var cards_in_slot = []
+var roulette_cards = []
 var base_position
 var base_z_index = 0
 var hover_z_index = 10
@@ -182,7 +183,8 @@ func start_roulette():
 	current_highlight_index = 0
 	roulette_elapsed_time = 0.0
 	final_slowdown_started = false
-	target_card_index = randi() % cards_in_slot.size()
+	roulette_cards = cards_in_slot.duplicate()  
+	target_card_index = randi() % roulette_cards.size()
 	total_roulette_time = randf_range(2.7, 3.5)
 	roulette_speed = 0.1
 	roulette_timer.wait_time = roulette_speed
@@ -191,11 +193,11 @@ func start_roulette():
 	_set_cards_collision_disabled(true)
 
 func _on_roulette_tick():
-	if not is_roulette_running:
+	if not is_roulette_running or roulette_cards.is_empty():
 		return
 	roulette_elapsed_time += roulette_timer.wait_time
 	_clear_current_highlight()
-	current_highlight_index = (current_highlight_index + 1) % cards_in_slot.size()
+	current_highlight_index = (current_highlight_index + 1) % roulette_cards.size()
 	_highlight_card_at_index(current_highlight_index)
 	var progress = roulette_elapsed_time / total_roulette_time
 	if progress >= 0.85 and not final_slowdown_started:
@@ -213,7 +215,7 @@ func _stop_roulette():
 	roulette_timer.stop()
 	is_roulette_running = false
 	_highlight_card_at_index(target_card_index)
-	highlighted_card = cards_in_slot[target_card_index]
+	highlighted_card = roulette_cards[target_card_index]   # вместо cards_in_slot
 	_set_cards_collision_disabled(false)
 	var final_timer = Timer.new()
 	final_timer.wait_time = 0.5

--- a/Scripts/SingleCardSlot.gd
+++ b/Scripts/SingleCardSlot.gd
@@ -87,8 +87,8 @@ func remove_card_from_slot(card):
 func get_top_card():
 	return null
 
-func bring_card_to_front(card):
-	pass
-
-func clear_hovered_card():
-	pass
+#func bring_card_to_front(card):
+	#pass
+#
+#func clear_hovered_card():
+	#pass


### PR DESCRIPTION
Introduces OpponentDeck and OpponentMatDeck nodes to Main.tscn with appropriate sprites and textures. Refactors popup menu handler parameters in several scripts for consistency. Improves roulette logic in MemoryCardsSlot.gd by duplicating card list for roulette operations and ensuring correct card selection.