### PR TITLE
Add opponent hand and deck functionality

### DIFF
--- a/Scenes/CardInformation.tscn
+++ b/Scenes/CardInformation.tscn
@@ -17,8 +17,14 @@ offset_top = 542.0
 offset_right = 408.0
 offset_bottom = 595.0
 
+[node name="Types and Suptypes" type="RichTextLabel" parent="."]
+offset_left = 36.0
+offset_top = 573.0
+offset_right = 436.0
+offset_bottom = 616.0
+
 [node name="Effect" type="RichTextLabel" parent="."]
 offset_left = 57.0
-offset_top = 602.0
+offset_top = 660.0
 offset_right = 408.0
-offset_bottom = 953.0
+offset_bottom = 1011.0

--- a/Scenes/Main.tscn
+++ b/Scenes/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=35 format=3 uid="uid://dqt16mao7lo7t"]
+[gd_scene load_steps=38 format=3 uid="uid://dqt16mao7lo7t"]
 
 [ext_resource type="Script" uid="uid://btk4g07uwv3gi" path="res://Scripts/CardManager.gd" id="1_uu6xs"]
 [ext_resource type="PackedScene" uid="uid://ml3qhw1idgmk" path="res://Scenes/CardsSlotForSingleCard.tscn" id="4_fos0i"]
@@ -15,13 +15,16 @@
 [ext_resource type="Script" uid="uid://bp1qbo2oxuy1p" path="res://Scripts/InputManager.gd" id="13_frkhe"]
 [ext_resource type="PackedScene" uid="uid://db2eqitvw1e27" path="res://Scenes/CardInformation.tscn" id="14_1p5hy"]
 [ext_resource type="PackedScene" uid="uid://cw3lmoyxw8aue" path="res://Scenes/Norm.tscn" id="15_h1m7h"]
+[ext_resource type="Script" uid="uid://bfjq0vc84eui2" path="res://Scripts/OpponentHand.gd" id="15_vvnwx"]
 [ext_resource type="PackedScene" uid="uid://d2q27vj536tlk" path="res://Scenes/Fire.tscn" id="16_2w5on"]
 [ext_resource type="Script" uid="uid://c57bimiwmr0yp" path="res://Scripts/Element.gd" id="16_5jffn"]
 [ext_resource type="PackedScene" uid="uid://cxd2mvn6wykfl" path="res://Scenes/Water.tscn" id="17_346fj"]
 [ext_resource type="Texture2D" uid="uid://yaxuiipbxmdg" path="res://Assets/Grand Archive/ga_back.png" id="17_qta6b"]
 [ext_resource type="PackedScene" uid="uid://8bexacpcoqme" path="res://Scenes/Wind.tscn" id="18_0sclb"]
+[ext_resource type="Script" uid="uid://bwyxwauuywjcq" path="res://Scripts/Opponent_GA_DECK.gd" id="18_btbly"]
 [ext_resource type="PackedScene" uid="uid://dykyungnxlstu" path="res://Scenes/Astra.tscn" id="19_sxkr1"]
 [ext_resource type="PackedScene" uid="uid://d1fe3gik6qku8" path="res://Scenes/Umbra.tscn" id="20_hwpts"]
+[ext_resource type="Script" uid="uid://cf80o7nhfih73" path="res://Scripts/Opponent_MAT_DECK.gd" id="20_vs04g"]
 [ext_resource type="PackedScene" uid="uid://barb5envijoxc" path="res://Scenes/Arcane.tscn" id="21_jyqft"]
 [ext_resource type="PackedScene" uid="uid://c65iuybt2dxtw" path="res://Scenes/Exia.tscn" id="22_hwpts"]
 [ext_resource type="PackedScene" uid="uid://c324fwephddgy" path="res://Scenes/Crux.tscn" id="23_3tgeq"]
@@ -88,23 +91,28 @@ script = ExtResource("8_vy5pj")
 [node name="PlayerHand" type="Node2D" parent="."]
 script = ExtResource("7_lgr22")
 
+[node name="EnemyHand" type="Node2D" parent="."]
+script = ExtResource("15_vvnwx")
+
 [node name="InputManager" type="Node2D" parent="."]
 script = ExtResource("13_frkhe")
 
 [node name="CardInformation" parent="." instance=ExtResource("14_1p5hy")]
 
 [node name="OpponentDeck" type="Node2D" parent="."]
+position = Vector2(599.5, 300)
+script = ExtResource("18_btbly")
 
 [node name="Sprite2D" type="Sprite2D" parent="OpponentDeck"]
-position = Vector2(599.5, 300)
 rotation = 3.14159
 scale = Vector2(0.192, 0.192)
 texture = ExtResource("17_qta6b")
 
 [node name="OpponentMatDeck" type="Node2D" parent="."]
+position = Vector2(1361, 300)
+script = ExtResource("20_vs04g")
 
 [node name="Sprite2D" type="Sprite2D" parent="OpponentMatDeck"]
-position = Vector2(1361, 300)
 rotation = 3.14159
 scale = Vector2(0.192, 0.192)
 texture = ExtResource("17_qta6b")

--- a/Scenes/OpponentCard.tscn
+++ b/Scenes/OpponentCard.tscn
@@ -1,0 +1,136 @@
+[gd_scene load_steps=6 format=3 uid="uid://jo76eg2ytpyo"]
+
+[ext_resource type="Script" uid="uid://b855tn1schyyc" path="res://Scripts/OpponentCard.gd" id="1_mv32a"]
+[ext_resource type="Texture2D" uid="uid://yaxuiipbxmdg" path="res://Assets/Grand Archive/ga_back.png" id="2_qrb68"]
+
+[sub_resource type="Animation" id="Animation_h8wm0"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("CardImageBack:scale")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(0.492, 0.492)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("CardImageBack:z_index")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [0]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("CardImage:z_index")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [-1]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("CardImage:scale")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(0.492, 0.492)]
+}
+
+[sub_resource type="Animation" id="Animation_3p273"]
+resource_name = "card_flip"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("CardImageBack:scale")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.1, 0.2),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector2(0.492, 0.492), Vector2(0.1, 0.492), Vector2(0.492, 0.492)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("CardImageBack:z_index")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.1),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [0, -1]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("CardImage:z_index")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 0.1),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [-1, 0]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("CardImage:scale")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.1, 0.2),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector2(0.492, 0.492), Vector2(0.1, 0.492), Vector2(0.492, 0.492)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_h8wm0"]
+_data = {
+&"RESET": SubResource("Animation_h8wm0"),
+&"card_flip": SubResource("Animation_3p273")
+}
+
+[node name="Card" type="Node2D"]
+z_index = -2
+texture_filter = 2
+position = Vector2(599.5, 300)
+scale = Vector2(0.39, 0.39)
+script = ExtResource("1_mv32a")
+
+[node name="CardImageBack" type="Sprite2D" parent="."]
+scale = Vector2(0.492, 0.492)
+texture = ExtResource("2_qrb68")
+
+[node name="CardImage" type="Sprite2D" parent="."]
+z_index = -1
+scale = Vector2(0.492, 0.492)
+texture = ExtResource("2_qrb68")
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+&"": SubResource("AnimationLibrary_h8wm0")
+}
+
+[node name="PopupMenu" type="PopupMenu" parent="."]
+size = Vector2i(100, 50)

--- a/Scripts/CardInformation.gd
+++ b/Scripts/CardInformation.gd
@@ -3,6 +3,8 @@ extends Node2D
 @onready var preview_sprite = $Sprite2D
 @onready var card_name_label = $Name
 @onready var card_effect_lable = $Effect
+@onready var card_types_lable = $"Types and Suptypes"
+
 var card_database_reference = null
 var default_texture = null
 var card_manager_reference = null
@@ -27,10 +29,30 @@ func _process(_delta: float) -> void:
 		if current_hovered_card != last_displayed_card:
 			show_card_preview(current_hovered_card)
 			last_displayed_card = current_hovered_card
+
 func show_card_info(slug: String):
 	current_displayed_slug = slug
 	last_displayed_card = null
 	_update_card_display(slug)
+	
+func _format_types(data: Dictionary) -> String:
+	var types_text = ""
+	var types_list = []
+	var subtypes_list = []
+	if data.has("types") and data["types"] is Array:
+		for t in data["types"]:
+			types_list.append(str(t).to_upper())
+	if data.has("subtypes") and data["subtypes"] is Array:
+		for s in data["subtypes"]:
+			subtypes_list.append(str(s).to_upper())
+		subtypes_list.sort()
+	if types_list.size() > 0:
+		types_text += " ".join(types_list)
+	if subtypes_list.size() > 0:
+		if types_text != "":
+			types_text += " - "
+		types_text += " ".join(subtypes_list)
+	return types_text
 
 func show_card_preview(card):
 	var card_slug = get_slug_from_card(card)
@@ -68,12 +90,14 @@ func _update_card_display(slug: String):
 		return
 	card_name_label.clear()
 	card_effect_lable.clear()
+	card_types_lable.clear()
 	if preview_sprite and slug != "":
 		var card_image_path = "res://Assets/Grand Archive/Card Images/" + slug + ".png"
 		if ResourceLoader.exists(card_image_path):
 			preview_sprite.texture = load(card_image_path)
 	var name_to_display = ""
 	var effect_to_display = ""
+	var types_to_display = ""
 	if card_database_reference and card_database_reference.cards_db.has(slug):
 		var data = card_database_reference.cards_db[slug]
 		if data.has("edition_id") and not data.has("parent_orientation_slug"):
@@ -82,27 +106,58 @@ func _update_card_display(slug: String):
 				var base_data = card_database_reference.cards_db[base_slug]
 				name_to_display = base_data.get("name", "")
 				effect_to_display = base_data.get("effect_raw", "")
+				types_to_display = _format_types(base_data)
+				if (effect_to_display == null or effect_to_display.strip_edges() == "") and base_data.get("flavor"):
+					effect_to_display = base_data["flavor"]
+				elif effect_to_display == null or effect_to_display.strip_edges() == "":
+					if base_data.has("editions"):
+						for edition in base_data["editions"]:
+							if edition.get("flavor"):
+								effect_to_display = edition["flavor"]
+								break
 		elif data.has("parent_orientation_slug"):
 			var parent_slug = data["parent_orientation_slug"]
 			if card_database_reference.cards_db.has(parent_slug):
 				var parent_data = card_database_reference.cards_db[parent_slug]
 				name_to_display = parent_data.get("name", "")
 				effect_to_display = parent_data.get("effect_raw", "")
+				types_to_display = _format_types(parent_data)
+				if (effect_to_display == null or effect_to_display.strip_edges() == "") and parent_data.get("flavor"):
+					effect_to_display = parent_data["flavor"]
+				elif effect_to_display == null or effect_to_display.strip_edges() == "":
+					if parent_data.has("editions"):
+						for edition in parent_data["editions"]:
+							if edition.get("flavor"):
+								effect_to_display = edition["flavor"]
+								break
 		else:
 			name_to_display = data.get("name", "")
 			effect_to_display = data.get("effect_raw", "")
-	if name_to_display != "":
+			types_to_display = _format_types(data)
+			if (effect_to_display == null or effect_to_display.strip_edges() == "") and data.get("flavor"):
+				effect_to_display = data["flavor"]
+			elif effect_to_display == null or effect_to_display.strip_edges() == "":
+				if data.has("editions"):
+					for edition in data["editions"]:
+						if edition.get("flavor"):
+							effect_to_display = edition["flavor"]
+							break
+	if name_to_display and name_to_display.strip_edges() != "":
 		var cleaned_name = fix_weird_quotes_and_dashes(name_to_display.strip_edges())
 		card_name_label.append_text("[center][b]%s[/b][/center]" % cleaned_name)
-	if effect_to_display != "":
+	if effect_to_display and effect_to_display.strip_edges() != "":
 		var cleaned_effect = fix_weird_quotes_and_dashes(effect_to_display.strip_edges())
 		card_effect_lable.append_text(cleaned_effect)
+	if types_to_display and types_to_display.strip_edges() != "":
+		card_types_lable.append_text("[center]%s[/center]" % types_to_display)
 
 func clear_preview():
 	if card_name_label:
 		card_name_label.clear()
 	if card_effect_lable:
 		card_effect_lable.clear()
+	if card_types_lable:
+		card_types_lable.clear()
 	if preview_sprite and default_texture:
 		preview_sprite.texture = default_texture
 	current_displayed_slug = ""
@@ -136,7 +191,7 @@ func get_slug_from_card(card) -> String:
 	if card.has_meta("slug"):
 		return card.get_meta("slug")
 	return ""
-	
+
 func fix_weird_quotes_and_dashes(text: String) -> String:
 	var replacements = {
 		"вЂ™": "'",

--- a/Scripts/MAT_DECK.gd
+++ b/Scripts/MAT_DECK.gd
@@ -11,7 +11,6 @@ const CARD_SCENE_PATH = "res://Scenes/Card.tscn"
 @onready var grid_container = $MAT_DECK_VIEW_WINDOW/ScrollContainer/GridContainer
 
 func _ready() -> void:
-	player_deck.shuffle()
 	card_database_reference = preload("res://Scripts/CardDatabase.gd")
 	setup_context_menu()
 	setup_deck_view()

--- a/Scripts/OpponentCard.gd
+++ b/Scripts/OpponentCard.gd
@@ -1,0 +1,16 @@
+extends Node2D
+
+var hand_position
+var mouse_inside = false
+
+func _ready() -> void:
+	if get_parent() and get_parent().has_method("connect_card_signals"):
+		get_parent().connect_card_signals(self)
+
+func _on_area_2d_mouse_entered() -> void:
+	mouse_inside = true
+	emit_signal("hovered", self)
+
+func _on_area_2d_mouse_exited() -> void:
+	mouse_inside = false
+	emit_signal("hovered_off", self)

--- a/Scripts/OpponentHand.gd
+++ b/Scripts/OpponentHand.gd
@@ -1,0 +1,342 @@
+extends Node2D
+
+signal animation_started
+signal animation_finished
+
+const CARD_WIDTH = 100
+const HAND_Y_POSITION = 0
+const FIELD_Z_INDEX = 0
+const HAND_Z_INDEX = 100
+const MIN_CARD_SPACING = 10
+const MAX_CARD_SPACING = 60
+const BASE_CURVE_HEIGHT = 10
+
+var HAND_FIELD_WIDTH = 600
+var opponent_hand = []
+var center_screen_x
+var hand_field_left
+var hand_field_right
+var active_tweens = 0
+var animation_in_progress = false
+var active_tween_objects = []
+var hovered_card = null
+var hand_hidden := false
+
+func _ready() -> void:
+	center_screen_x = get_viewport().size.x / 2
+	hand_field_left = center_screen_x - HAND_FIELD_WIDTH / 2.0
+	hand_field_right = center_screen_x + HAND_FIELD_WIDTH / 2.0
+
+func _notification(what):
+	if what == NOTIFICATION_PREDELETE:
+		cleanup()
+
+func _exit_tree():
+	cleanup()
+
+func add_card_to_hand(card):
+	if not card or not is_instance_valid(card):
+		return
+	if card not in opponent_hand:
+		opponent_hand.append(card)
+		card.z_index = HAND_Z_INDEX + opponent_hand.size()
+		update_hand_position()
+		if hand_hidden:
+			show_card(card)
+			var start_pos = card.position
+			var logo_pos = Vector2(590, 960)
+			var offscreen_pos = Vector2(2500, 1200)
+			card.position = start_pos
+			var tween = create_tween()
+			tween.tween_property(card, "position", logo_pos, 0.3)
+			tween.tween_callback(Callable(self, "_move_card_offscreen").bind(card, offscreen_pos))
+			if card.has_node("Area2D"):
+				card.get_node("Area2D").set_deferred("input_pickable", false)
+		else:
+			show_card(card)
+	else:
+		var card_index = opponent_hand.find(card)
+		if card_index >= 0:
+			var rotations = calculate_card_rotation(card_index)
+			animate_card_to_position(card, card.hand_position, rotations)
+
+func update_hand_position():
+	validate_hand()
+	if opponent_hand.is_empty():
+		return
+	start_animation()
+	for i in range(opponent_hand.size()):
+		var card = opponent_hand[i]
+		if card and is_instance_valid(card):
+			var new_position = calculate_card_position(i)
+			var new_rotation = calculate_card_rotation(i)
+			card.hand_position = new_position
+			card.z_index = HAND_Z_INDEX + i + 1
+			animate_card_to_position(card, new_position, new_rotation)
+
+func calculate_card_position(index):
+	var hand_size = opponent_hand.size()
+	if hand_size == 1:
+		return Vector2(center_screen_x, HAND_Y_POSITION)
+	var card_spacing = calculate_card_spacing(hand_size)
+	var total_width = (hand_size - 1) * card_spacing
+	var start_x = center_screen_x - total_width / 2
+	var x_position = start_x + index * card_spacing
+	var leftmost_card = start_x - CARD_WIDTH / 2.0
+	var rightmost_card = start_x + total_width + CARD_WIDTH / 2.0
+	if leftmost_card < hand_field_left or rightmost_card > hand_field_right:
+		var available_width = HAND_FIELD_WIDTH - CARD_WIDTH
+		if hand_size > 1:
+			card_spacing = available_width / (hand_size - 1.0)
+		total_width = (hand_size - 1) * card_spacing
+		start_x = center_screen_x - total_width / 2
+		x_position = start_x + index * card_spacing
+	var ratio = 0.0
+	if hand_size > 1:
+		ratio = float(index) / float(hand_size - 1)
+	var curve_height = calculate_curve_height(hand_size)
+	var curve_factor = 4 * ratio * (1.0 - ratio)
+	var y_position = HAND_Y_POSITION - curve_factor * curve_height
+	return Vector2(x_position, y_position)
+
+func calculate_card_spacing(hand_size):
+	if hand_size <= 1:
+		return MAX_CARD_SPACING
+	var ideal_spacing = MAX_CARD_SPACING
+	var total_width = (hand_size - 1) * ideal_spacing + CARD_WIDTH
+	if total_width > HAND_FIELD_WIDTH:
+		ideal_spacing = (HAND_FIELD_WIDTH - CARD_WIDTH) / (hand_size - 1)
+		ideal_spacing = max(ideal_spacing, MIN_CARD_SPACING)
+	return ideal_spacing
+
+func calculate_curve_height(hand_size):
+	if hand_size == 3:
+		return 4
+	elif hand_size == 4:
+		return 6
+	elif hand_size == 5:
+		return 8
+	else:
+		return BASE_CURVE_HEIGHT  
+
+func get_dynamic_max_angle(hand_size: int) -> float:
+	if hand_size <= 1:
+		return 0.0
+	elif hand_size <= 3:
+		return lerp(0.0, 6.0, (hand_size - 1) / 4.0)
+	else:
+		return clamp(30.0 / sqrt(hand_size), 4.0, 6.0)
+
+func calculate_card_rotation(index):
+	var hand_size = opponent_hand.size()
+	if hand_size <= 1:
+		return 0.0
+	var dynamic_max_angle = get_dynamic_max_angle(hand_size)
+	var ratio = float(index) / (float(hand_size) - 1)
+	var angle = lerp(-dynamic_max_angle, dynamic_max_angle, ratio)
+	return deg_to_rad(angle)
+
+func animate_card_to_position(card, new_position, new_rotation = 0.0):
+	if not card or not is_instance_valid(card):
+		return
+	active_tweens += 1
+	var tween = create_tween()
+	active_tween_objects.append(tween)
+	tween.parallel().tween_property(card, "position", new_position, 0.3)
+	tween.parallel().tween_property(card, "rotation", new_rotation, 0.3)
+	tween.finished.connect(_on_tween_finished.bind(tween), CONNECT_ONE_SHOT)
+
+func _on_tween_finished(tween):
+	active_tweens -= 1
+	if active_tweens <= 0:
+		active_tweens = 0
+		end_animation()
+	if tween and tween in active_tween_objects:
+		active_tween_objects.erase(tween)
+
+func start_animation():
+	if not animation_in_progress:
+		animation_in_progress = true
+		animation_started.emit()
+
+func end_animation():
+	animation_in_progress = false
+	animation_finished.emit()
+
+func remove_card_from_hand(card):
+	if not card or not is_instance_valid(card):
+		return
+	if card in opponent_hand:
+		disconnect_card_signals(card)
+		opponent_hand.erase(card)
+		card.rotation = 0.0
+		if not opponent_hand.is_empty():
+			update_hand_position()
+		else:
+			active_tweens = 0
+			end_animation()
+
+func reset_card_rotation(card, target_rotation = 0.0):
+	if not card or not is_instance_valid(card):
+		return
+	var tween = create_tween()
+	active_tween_objects.append(tween)
+	tween.tween_property(card, "rotation", target_rotation, 0.2)
+	tween.finished.connect(_on_single_tween_finished.bind(tween), CONNECT_ONE_SHOT)
+
+func _on_single_tween_finished(tween):
+	if tween and tween in active_tween_objects:
+		active_tween_objects.erase(tween)
+
+func place_card_in_field(card, field_position, field_rotation = 0.0):
+	if not card or not is_instance_valid(card):
+		return
+	if card in opponent_hand:
+		opponent_hand.erase(card)
+		if not opponent_hand.is_empty():
+			update_hand_position()
+		else:
+			end_animation()
+	card.z_index = FIELD_Z_INDEX
+	var tween = create_tween()
+	active_tween_objects.append(tween)
+	tween.parallel().tween_property(card, "position", field_position, 0.3)
+	tween.parallel().tween_property(card, "rotation", field_rotation, 0.3)
+	tween.finished.connect(_on_single_tween_finished.bind(tween), CONNECT_ONE_SHOT)
+
+func return_card_to_hand(card):
+	if not card or not is_instance_valid(card):
+		return
+	if card not in opponent_hand:
+		opponent_hand.append(card)
+		card.z_index = HAND_Z_INDEX + opponent_hand.size()
+		update_hand_position()
+
+func organise_cards(cards: Array) -> void:
+	opponent_hand.clear()
+	for card in cards:
+		if card and is_instance_valid(card):
+			opponent_hand.append(card)
+	update_hand_position()
+
+func set_hand_field_width(new_width: float):
+	HAND_FIELD_WIDTH = new_width
+	hand_field_left = center_screen_x - HAND_FIELD_WIDTH / 2
+	hand_field_right = center_screen_x + HAND_FIELD_WIDTH / 2
+	if not opponent_hand.is_empty():
+		update_hand_position()
+
+func bring_card_to_front(card):
+	if not card or not is_instance_valid(card):
+		return
+	hovered_card = card
+	var hovered_card_index = opponent_hand.find(card)
+	if hovered_card_index == -1:
+		return
+	var hand_size = opponent_hand.size()
+	for i in range(hand_size):
+		var current_card = opponent_hand[i]
+		if current_card and is_instance_valid(current_card):
+			if i >= hovered_card_index:
+				current_card.z_index = HAND_Z_INDEX + i + 100
+			else:
+				current_card.z_index = HAND_Z_INDEX + i + 1
+
+func clear_hovered_card():
+	hovered_card = null
+	var hand_size = opponent_hand.size()
+	for i in range(hand_size):
+		var card = opponent_hand[i]
+		if card and is_instance_valid(card):
+			card.z_index = HAND_Z_INDEX + i + 1
+
+func hide_hand():
+	hand_hidden = true
+	for card in opponent_hand:
+		hide_card_with_animation(card)
+
+func show_hand():
+	hand_hidden = false
+	var logo_pos = Vector2(590, 960)
+	for i in range(opponent_hand.size()):
+		var card = opponent_hand[i]
+		if card and is_instance_valid(card):
+			card.position = logo_pos
+			card.visible = true
+			if card.has_node("Area2D"):
+				card.get_node("Area2D").set_deferred("input_pickable", true)
+	update_hand_position()
+
+func hide_card_with_animation(card):
+	if card and is_instance_valid(card):
+		var logo_pos = Vector2(590, 960)
+		var offscreen_pos = Vector2(3300, 3300)
+		var tween = create_tween()
+		tween.tween_property(card, "position", logo_pos, 0.3)
+		tween.tween_callback(Callable(self, "_move_card_offscreen").bind(card, offscreen_pos))
+		if card.has_node("Area2D"):
+			card.get_node("Area2D").set_deferred("input_pickable", false)
+
+func _move_card_offscreen(card, offscreen_pos):
+	if card and is_instance_valid(card):
+		card.position = offscreen_pos
+		card.visible = false
+
+func hide_card(card):
+	if card and is_instance_valid(card):
+		card.position = Vector2(2500, 1200)
+		card.visible = false
+		if card.has_node("Area2D"):
+			card.get_node("Area2D").set_deferred("input_pickable", false)
+
+func show_card(card):
+	if card and is_instance_valid(card):
+		card.visible = true
+		if card.has_node("Area2D"):
+			card.get_node("Area2D").set_deferred("input_pickable", true)
+
+func toggle_hand_visibility():
+	if hand_hidden:
+		show_hand()
+	else:
+		hide_hand()
+
+func set_card_z_index(card, z_value: int):
+	if card and is_instance_valid(card):
+		card.z_index = z_value
+
+func has_cards() -> bool:
+	validate_hand()
+	return not opponent_hand.is_empty()
+
+func get_hand_count() -> int:
+	validate_hand()
+	return opponent_hand.size()
+
+func is_hand_empty() -> bool:
+	validate_hand()
+	return opponent_hand.is_empty()
+
+func validate_hand():
+	var invalid_cards = []
+	for card in opponent_hand:
+		if not card or not is_instance_valid(card):
+			invalid_cards.append(card)
+	for invalid_card in invalid_cards:
+		opponent_hand.erase(invalid_card)
+
+func disconnect_card_signals(card):
+	if not card or not is_instance_valid(card) or not card.has_node("Area2D"):
+		return
+		
+func cleanup():
+	for tween in active_tween_objects:
+		if tween and tween.is_valid():
+			tween.kill()
+	active_tween_objects.clear()
+	for card in opponent_hand:
+		if card and is_instance_valid(card):
+			disconnect_card_signals(card)
+	opponent_hand.clear()
+	active_tweens = 0
+	animation_in_progress = false

--- a/Scripts/Opponent_GA_DECK.gd
+++ b/Scripts/Opponent_GA_DECK.gd
@@ -1,0 +1,32 @@
+extends Node2D
+
+var opponent_deck = ["alice-golden-queen-dtr1e-cur","aetheric-calibration-dtrsd","alice-golden-queen-dtr","academy-guide-p24", "absolving-flames-amb","acolyte-of-cultivation-amb","acolyte-of-cultivation-amb"
+,"suzaku-vermillion-phoenix-hvn1e-csr","acolyte-of-cultivation-amb","arcane-disposition-doap","arthur-young-heir-evp","suzaku-vermillion-phoenix-hvn1e"]
+
+var card_database_reference
+const CARD_SCENE_PATH = "res://Scenes/OpponentCard.tscn"
+
+func _ready() -> void:
+	opponent_deck.shuffle()
+
+func draw_card():
+	if opponent_deck.size() == 0:
+		return
+	var card_drawn_name = opponent_deck[0]
+	opponent_deck.erase(card_drawn_name)
+	if opponent_deck.size() == 0:
+		$Sprite2D.visible = false
+	var card_scene = preload(CARD_SCENE_PATH)
+	var new_card = card_scene.instantiate()
+	var card_image_path = "res://Assets/Grand Archive/Card Images/" + card_drawn_name + ".png"
+	if ResourceLoader.exists(card_image_path):
+		new_card.get_node("CardImage").texture = load(card_image_path)
+	new_card.set_meta("slug", card_drawn_name)
+	var unique_name = card_drawn_name
+	var counter = 2
+	while $"../CardManager".has_node(unique_name):
+		unique_name = "%s (%d)" % [card_drawn_name, counter]
+		counter += 1
+	new_card.name = unique_name
+	$"../CardManager".add_child(new_card)
+	$"../OpponentHand".add_card_to_hand(new_card)

--- a/Scripts/Opponent_MAT_DECK.gd
+++ b/Scripts/Opponent_MAT_DECK.gd
@@ -1,0 +1,10 @@
+extends Node2D
+
+var opponent_deck = ["alice-golden-queen-dtr1e-cur","aetheric-calibration-dtrsd","alice-golden-queen-dtr","academy-guide-p24", "absolving-flames-amb","acolyte-of-cultivation-amb","acolyte-of-cultivation-amb"
+,"suzaku-vermillion-phoenix-hvn1e-csr","acolyte-of-cultivation-amb","arcane-disposition-doap","arthur-young-heir-evp","suzaku-vermillion-phoenix-hvn1e"]
+
+var card_database_reference
+const CARD_SCENE_PATH = "res://Scenes/OpponentCard.tscn"
+
+func _ready() -> void:
+	card_database_reference = preload("res://Scripts/CardDatabase.gd")


### PR DESCRIPTION
Introduces OpponentHand, OpponentCard, Opponent_GA_DECK, and Opponent_MAT_DECK scripts and scenes to support opponent card management and drawing. Updates Main.tscn to include opponent hand and deck nodes, and enhances CardInformation to display card types and subtypes. Also refines card preview and effect display logic.