### PR TITLE
Track card field location and add rotation logic

### DIFF
--- a/Scripts/90DegreesCardSlot.gd
+++ b/Scripts/90DegreesCardSlot.gd
@@ -71,6 +71,8 @@ func _on_deck_view_close():
 	banish_view_window.hide()
 
 func add_card_to_slot(card):
+	if card.has_method("set_current_field"):
+		card.set_current_field(self)
 	cards_in_banish.append(card)
 	card.global_position = global_position
 	card.z_index = base_z_index + cards_in_banish.size()
@@ -81,6 +83,8 @@ func add_card_to_slot(card):
 
 func remove_card_from_slot(card):
 	if card in cards_in_banish:
+		if card.has_method("set_current_field"):
+			card.set_current_field(null)
 		cards_in_banish.erase(card)
 		if cards_in_banish.is_empty():
 			card_in_slot = false

--- a/Scripts/Card.gd
+++ b/Scripts/Card.gd
@@ -3,6 +3,9 @@ extends Node2D
 signal hovered
 signal hovered_off
 
+var current_field = null
+var original_rotation = 0.0
+var is_rotated = false
 var hand_position
 var mouse_inside = false
 
@@ -16,15 +19,22 @@ func _on_area_2d_input_event(_viewport: Node, event: InputEvent, _shape_idx: int
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
 		if mouse_inside:
 			$PopupMenu.clear()
+			if $PopupMenu.has_theme_constant_override("separation"):
+				$PopupMenu.add_theme_constant_override("separation", 1)
 			$PopupMenu.add_item("Go to Graveyard", 0)
 			$PopupMenu.add_item("Go to Banish FU", 1)
 			$PopupMenu.add_item("Go to Banish FD", 2)
 			$PopupMenu.add_item("Go to TD", 3)
 			$PopupMenu.add_item("Go to BD", 4)
-			$PopupMenu.add_item("Rotate", 5)
+			if is_in_main_field():
+				if is_rotated:
+					$PopupMenu.add_item("Awake", 5)
+				else:
+					$PopupMenu.add_item("Rest", 5)
 			$PopupMenu.add_item("Show", 6)
 			$PopupMenu.add_item("Transform", 7)
 			$PopupMenu.add_item("Give to your opponent", 8)
+			$PopupMenu.reset_size()
 			$PopupMenu.position = get_global_mouse_position()
 			$PopupMenu.popup()
 
@@ -43,7 +53,33 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 		2: print("Go to Banish FD selected")
 		3: print("Go to TD selected")
 		4: print("Go to BD selected")
-		5: print("Rotate selected")
+		5: if is_in_main_field():
+			rotate_card()
 		6: print("Show selected")
-		7: print("Transform")
-		7: print("Give to your opponent")
+		7: print("Transform selected")
+		8: print("Give to your opponent")
+
+func rotate_card():
+	if not is_in_main_field():
+		return
+	if is_rotated:
+		rotation_degrees = original_rotation
+		is_rotated = false
+	else:
+		rotation_degrees = original_rotation + 90
+		is_rotated = true
+
+func set_current_field(field):
+	current_field = field
+
+func is_in_main_field() -> bool:
+	return current_field != null and current_field.is_in_group("main_fields")
+
+func is_in_memory_slot() -> bool:
+	return current_field != null and current_field.is_in_group("memory_slots")
+
+func is_in_graveyard() -> bool:
+	return current_field != null and current_field.is_in_group("single_card_slots")
+
+func is_in_banish() -> bool:
+	return current_field != null and current_field.is_in_group("rotated_slots")

--- a/Scripts/GA_DECK.gd
+++ b/Scripts/GA_DECK.gd
@@ -11,6 +11,7 @@ const CARD_SCENE_PATH = "res://Scenes/Card.tscn"
 @onready var grid_container = $DeckViewWindow/ScrollContainer/GridContainer
 
 func _ready() -> void:
+	add_to_group("deck_zones")
 	player_deck.shuffle()
 	card_database_reference = preload("res://Scripts/CardDatabase.gd")
 	setup_context_menu()

--- a/Scripts/MAT_DECK.gd
+++ b/Scripts/MAT_DECK.gd
@@ -11,6 +11,7 @@ const CARD_SCENE_PATH = "res://Scenes/Card.tscn"
 @onready var grid_container = $MAT_DECK_VIEW_WINDOW/ScrollContainer/GridContainer
 
 func _ready() -> void:
+	add_to_group("mat_deck_zones")
 	card_database_reference = preload("res://Scripts/CardDatabase.gd")
 	setup_context_menu()
 	setup_deck_view()

--- a/Scripts/Main_Field.gd
+++ b/Scripts/Main_Field.gd
@@ -15,12 +15,20 @@ func add_card_to_field(card, position = null):
 		card.global_position = position
 	cards_in_field.append(card)
 	card_in_slot = true
+	
+	# Сетваме референцията към field-а в картата
+	if card.has_method("set_current_field"):
+		card.set_current_field(self)
 
 func remove_card_from_field(card):
 	if card in cards_in_field:
 		cards_in_field.erase(card)
 		if cards_in_field.is_empty():
 			card_in_slot = false
+		
+		# Премахваме referencer към field-а
+		if card.has_method("set_current_field"):
+			card.set_current_field(null)
 
 func bring_card_to_front(card):
 	if not card or not is_instance_valid(card):

--- a/Scripts/MemoryCardsSlot.gd
+++ b/Scripts/MemoryCardsSlot.gd
@@ -35,12 +35,17 @@ func _on_global_lmb_released():
 	reset_card_colors()
 
 func add_card_to_memory(card):
+	if card.has_method("set_current_field"):
+		card.set_current_field(self)
+
 	cards_in_slot.append(card)
 	show_card_back(card)
 	arrange_cards_symmetrically()
 
 func remove_card_from_memory(card):
 	if card in cards_in_slot:
+		if card.has_method("set_current_field"):
+			card.set_current_field(null)
 		cards_in_slot.erase(card)
 		show_card_front(card)
 		arrange_cards_symmetrically()
@@ -104,6 +109,8 @@ func show_card_front(card):
 			card_image.texture = card.get_meta("original_card_texture")
 
 func insert_card_at_position(card, index):
+	if card.has_method("set_current_field"):
+		card.set_current_field(self)
 	if index < 0:
 		index = 0
 	elif index > cards_in_slot.size():

--- a/Scripts/PlayerHand.gd
+++ b/Scripts/PlayerHand.gd
@@ -37,6 +37,8 @@ func _exit_tree():
 func add_card_to_hand(card):
 	if not card or not is_instance_valid(card):
 		return
+	if card.has_method("set_current_field"):
+		card.set_current_field(self)
 	if card not in player_hand:
 		player_hand.append(card)
 		card.z_index = HAND_Z_INDEX + player_hand.size()
@@ -207,6 +209,8 @@ func place_card_in_field(card, field_position, field_rotation = 0.0):
 func return_card_to_hand(card):
 	if not card or not is_instance_valid(card):
 		return
+	if card.has_method("set_current_field"):
+		card.set_current_field(self)
 	if card not in player_hand:
 		player_hand.append(card)
 		card.z_index = HAND_Z_INDEX + player_hand.size()

--- a/Scripts/SingleCardSlot.gd
+++ b/Scripts/SingleCardSlot.gd
@@ -71,6 +71,8 @@ func _on_deck_view_close():
 	graveyard_view_window.hide()
 
 func add_card_to_slot(card):
+	if card.has_method("set_current_field"):
+		card.set_current_field(self)
 	cards_in_graveyard.append(card)
 	card.global_position = global_position
 	card.z_index = base_z_index + cards_in_graveyard.size()
@@ -80,6 +82,8 @@ func add_card_to_slot(card):
 
 func remove_card_from_slot(card):
 	if card in cards_in_graveyard:
+		if card.has_method("set_current_field"):
+			card.set_current_field(null)
 		cards_in_graveyard.erase(card)
 		if cards_in_graveyard.is_empty():
 			card_in_slot = false


### PR DESCRIPTION
Introduces a 'current_field' property to Card.gd and updates all slot and field scripts to set or clear this reference when cards are added or removed. Adds rotation and state logic for cards in the main field, updating context menu options to reflect card state. Also adds group assignments to deck zones for easier field type checks.