### PR TITLE
Add submenu support to Logo popup menu

### DIFF
--- a/Scenes/Logo.tscn
+++ b/Scenes/Logo.tscn
@@ -10,3 +10,4 @@ collision_mask = 32
 polygon = PackedVector2Array(-3, -35, -9, -29, -38, -19, -45, -23, -44, -7, -56, 15, -50, 24, -34, 30, -8, 25, -4, 36, 1, 25, 27, 31, 43, 26, 50, 16, 38, -7, 39, -22, 31, -20, 3, -29)
 
 [node name="PopupMenu" type="PopupMenu" parent="."]
+hide_on_item_selection = false

--- a/Scripts/Logo.gd
+++ b/Scripts/Logo.gd
@@ -1,13 +1,104 @@
 extends Node2D
 
 @onready var popup_menu: PopupMenu = $PopupMenu
+var showing_dice_menu := false
+var showing_rps_menu := false
 
 func _ready():
 	$Area2D.input_pickable = true
 	$Area2D.connect("input_event", Callable(self, "_on_Area2D_input_event"))
-	popup_menu.clear()
-	popup_menu.add_item("Memory Random", 0)
+	build_main_menu()
 	popup_menu.connect("id_pressed", Callable(self, "_on_popup_menu_id_pressed"))
+
+func build_main_menu():
+	showing_dice_menu = false
+	showing_rps_menu = false
+	popup_menu.clear()
+	popup_menu.add_item("Memory Random", 100)
+	popup_menu.add_item("Coin Flip", 101)
+	popup_menu.add_item("Roll Dice", 102)
+	popup_menu.add_item("RPS", 104)
+	popup_menu.add_separator()
+	popup_menu.add_item("Surrender", 103)
+	$PopupMenu.reset_size()
+
+func build_dice_menu():
+	showing_dice_menu = true
+	showing_rps_menu = false
+	popup_menu.clear()
+	popup_menu.add_item("D6", 6)
+	popup_menu.add_item("D8", 8)
+	popup_menu.add_item("D20", 20)
+	popup_menu.add_separator()
+	popup_menu.add_item("Back", 999)
+
+func build_rps_menu():
+	showing_dice_menu = false
+	showing_rps_menu = true
+	popup_menu.clear()
+	popup_menu.add_item("Rock", 201)
+	popup_menu.add_item("Paper", 202)
+	popup_menu.add_item("Scissors", 203)
+	popup_menu.add_separator()
+	popup_menu.add_item("Back", 999)
+
+func _on_Area2D_input_event(_viewport, event, _shape_idx):
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+		var player_hand_node = find_node_recursive(get_tree().get_root(), "PlayerHand")
+		if player_hand_node:
+			player_hand_node.toggle_hand_visibility()
+	elif event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+		var mouse_pos = get_global_mouse_position()
+		popup_menu.set_position(mouse_pos)
+		popup_menu.popup()
+		$PopupMenu.reset_size()
+		var screen_size = get_viewport().get_visible_rect().size
+		var menu_size = popup_menu.get_contents_minimum_size()
+		if mouse_pos.y + menu_size.y > screen_size.y:
+			var new_y = screen_size.y - menu_size.y
+			if new_y < 0:
+				new_y = 0
+			popup_menu.set_position(Vector2(mouse_pos.x, new_y))
+
+func _on_popup_menu_id_pressed(id):
+	if not showing_dice_menu and not showing_rps_menu:
+		if id == 100:
+			popup_menu.hide()
+			var memory_slot = find_node_recursive(get_tree().get_root(), "MEMORY")
+			if memory_slot:
+				memory_slot.highlight_random_card()
+		elif id == 101:
+			popup_menu.hide()
+			var result = ["HEAD", "TAIL"].pick_random()
+			print("SYSTEM: COIN - " + result)
+		elif id == 102:
+			build_dice_menu()
+		elif id == 104:
+			build_rps_menu()
+		elif id == 103:
+			popup_menu.hide()
+			print("SYSTEM: Player surrendered")
+	elif showing_dice_menu:
+		if id == 999:
+			build_main_menu()
+		else:
+			popup_menu.hide()
+			var roll = randi_range(1, id)
+			print("SYSTEM: D" + str(id) + " - " + str(roll))
+	elif showing_rps_menu:
+		if id == 999:
+			build_main_menu()
+		else:
+			popup_menu.hide()
+			var choice = ""
+			if id == 201:
+				choice = "Rock"
+			elif id == 202:
+				choice = "Paper"
+			elif id == 203:
+				choice = "Scissors"
+			print("SYSTEM: RPS - " + choice)
+	$PopupMenu.reset_size()
 
 func find_node_recursive(node, target_name):
 	if node.name == target_name:
@@ -17,19 +108,3 @@ func find_node_recursive(node, target_name):
 		if found:
 			return found
 	return null
-
-func _on_Area2D_input_event(_viewport, event, _shape_idx):
-	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-		var player_hand_node = find_node_recursive(get_tree().get_root(), "PlayerHand")
-		if player_hand_node:
-			player_hand_node.toggle_hand_visibility()
-	elif event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
-		popup_menu.set_position(get_global_mouse_position())
-		popup_menu.popup()
-		$PopupMenu.reset_size()
-
-func _on_popup_menu_id_pressed(id):
-	if id == 0:
-		var memory_slot = find_node_recursive(get_tree().get_root(), "MEMORY")
-		if memory_slot:
-			memory_slot.highlight_random_card()


### PR DESCRIPTION
Refactored Logo.gd to support multi-level popup menus for dice rolls and rock-paper-scissors. Added functions to build main, dice, and RPS menus, and updated event handling to manage submenu navigation and actions. Also set 'hide_on_item_selection' to false in Logo.tscn to allow submenu interaction.