### PR TITLE
Add champion card management to Main_Field

### DIFF
--- a/Scripts/Main_Field.gd
+++ b/Scripts/Main_Field.gd
@@ -3,20 +3,108 @@ extends Node2D
 var cards_in_field = []
 var base_position
 var card_in_slot = false
+var current_champion_card = null
 
 func _ready() -> void:
 	base_position = Vector2.ZERO
 	add_to_group("main_fields")
 
 func add_card_to_field(card, position = null):
-	if position == null:
+	if is_champion_card(card):
+		var card_already_in_field = card in cards_in_field
+		if not card_already_in_field:
+			if current_champion_card != null and current_champion_card != card:
+				remove_previous_champions()
+			current_champion_card = card
+			cards_in_field.append(card)
+			card_in_slot = true
 		card.global_position = global_position
+		card.z_index = 400
+		if card.has_method("set_current_field"):
+			card.set_current_field(self)
 	else:
-		card.global_position = position
-	cards_in_field.append(card)
-	card_in_slot = true
-	if card.has_method("set_current_field"):
-		card.set_current_field(self)
+		if not (card in cards_in_field):
+			cards_in_field.append(card)
+			card_in_slot = true
+		if card.has_method("set_current_field"):
+			card.set_current_field(self)
+		if position != null:
+			card.global_position = position
+
+func remove_previous_champions():
+	if current_champion_card and is_instance_valid(current_champion_card):
+		cards_in_field.erase(current_champion_card)
+		if current_champion_card.has_method("set_current_field"):
+			current_champion_card.set_current_field(null)
+		if current_champion_card.get_parent():
+			current_champion_card.get_parent().remove_child(current_champion_card)
+		current_champion_card.queue_free()
+		current_champion_card = null
+func is_champion_card(card) -> bool:
+	if not card or not is_instance_valid(card):
+		return false
+	var card_slug = get_card_slug(card)
+	if card_slug == "":
+		return false
+	var card_info_ref = find_card_information_reference()
+	if not card_info_ref or not card_info_ref.card_database_reference:
+		return false
+	var card_database = card_info_ref.card_database_reference
+	if not card_database.cards_db.has(card_slug):
+		return false
+	var data = card_database.cards_db[card_slug]
+	if data.has("types") and data["types"] is Array:
+		for card_type in data["types"]:
+			if str(card_type).to_upper() == "CHAMPION":
+				return true
+	if data.has("edition_id") and not data.has("parent_orientation_slug"):
+		var base_slug = find_base_card_for_edition(data["edition_id"], card_database)
+		if base_slug and card_database.cards_db.has(base_slug):
+			var base_data = card_database.cards_db[base_slug]
+			if base_data.has("types") and base_data["types"] is Array:
+				for card_type in base_data["types"]:
+					if str(card_type).to_upper() == "CHAMPION":
+						return true
+	elif data.has("parent_orientation_slug"):
+		var parent_slug = data["parent_orientation_slug"]
+		if card_database.cards_db.has(parent_slug):
+			var parent_data = card_database.cards_db[parent_slug]
+			if parent_data.has("types") and parent_data["types"] is Array:
+				for card_type in parent_data["types"]:
+					if str(card_type).to_upper() == "CHAMPION":
+						return true
+	return false
+
+func get_card_slug(card) -> String:
+	if card.has_meta("slug"):
+		return card.get_meta("slug")
+	return ""
+
+func find_card_information_reference():
+	var root = get_tree().current_scene
+	if root:
+		return find_node_by_script(root, "res://Scripts/CardInformation.gd")
+	return null
+
+func find_node_by_script(node: Node, script_path: String) -> Node:
+	if node.get_script() and node.get_script().resource_path == script_path:
+		return node
+	for child in node.get_children():
+		var result = find_node_by_script(child, script_path)
+		if result:
+			return result
+	return null
+
+func find_base_card_for_edition(edition_id, card_database):
+	if not card_database:
+		return null
+	for slug in card_database.cards_db:
+		var data = card_database.cards_db[slug]
+		if data.has("editions"):
+			for edition in data["editions"]:
+				if edition.get("edition_id") == edition_id:
+					return slug
+	return null
 
 func remove_card_from_field(card):
 	if card in cards_in_field:
@@ -25,6 +113,8 @@ func remove_card_from_field(card):
 			card_in_slot = false
 		if card.has_method("set_current_field"):
 			card.set_current_field(null)
+		if card == current_champion_card:
+			current_champion_card = null
 
 func bring_card_to_front(card):
 	if not card or not is_instance_valid(card):


### PR DESCRIPTION
Introduces logic to identify and manage champion cards in the field, ensuring only one champion card is present at a time. Adds helper functions for card type detection and database lookups, and updates card addition/removal to handle champion-specific behavior.