### PR TITLE
Add card transform functionality and menu logic

### DIFF
--- a/Scripts/Card.gd
+++ b/Scripts/Card.gd
@@ -16,6 +16,135 @@ var mouse_inside = false
 var was_rotated_before_drag = false
 var card_information_reference = null
 
+const TRANSFORMABLE_SLUGS := [
+	"huaji-of-heavens-rise-hvn1e","huaji-of-abyssal-fall-hvn1e","fatestone-of-balance-hvn",
+	"woodland-shoats-hvn","fatestone-of-progress-hvn","airborne-squirrel-hvn",
+	"fluvial-fatestone-hvn","mocking-otter-hvn","cyclonic-fatestone-hvn",
+	"windstalker-wolf-hvn","wildgrowth-fatestone-hvn","elder-mandrill-hvn",
+	"companion-fatestone-rec-hvf","fatebound-caracal-rec-hvf","companion-fatestone-p25",
+	"fatebound-caracal-p25","fatestone-of-revelations-rec-hvf","young-wyrmling-rec-hvf",
+	"fatestone-of-revelations-p25","young-wyrmling-p25","submerged-fatestone-hvn",
+	"commanding-sea-titan-hvn","fatestone-of-unrelenting-rec-hvf","cheetah-of-bound-fury-rec-hvf",
+	"fatestone-of-unrelenting-p25","cheetah-of-bound-fury-p25","lavaplume-fatestone-rec-hvf",
+	"firebird-trailblazer-rec-hvf","lavaplume-fatestone-p25","firebird-trailblazer-p25",
+	"idle-fatestone-hvn","bolstered-boar-hvn","coiled-fatestone-hvn",
+	"serpentine-judicator-hvn","pelagic-fatestone-hvn","slick-torrentrider-hvn",
+	"beseeched-fatestone-hvn","daunting-panda-hvn",
+	"craggy-fatestone-rec-hvf","obstinate-cragback-rec-hvf","craggy-fatestone-p25",
+	"obstinate-cragback-p25","fatestone-of-heaven-rec-hvf","heavenly-drake-rec-hvf",
+	"fatestone-of-heaven-p25","heavenly-drake-p25","fabled-ruby-fatestone-hvn1e",
+	"suzaku-vermillion-phoenix-hvn1e","fabled-ruby-fatestone-hvn1e-csr","suzaku-vermillion-phoenix-hvn1e-csr",
+	"fabled-sapphire-fatestone-hvn1e","genbu-black-tortoise-hvn1e","fabled-sapphire-fatestone-hvn1e-csr",
+	"genbu-black-tortoise-hvn1e-csr","fabled-emerald-fatestone-hvn1e","byakko-white-tiger-hvn1e",
+	"fabled-emerald-fatestone-hvn1e-csr","byakko-white-tiger-hvn1e-csr","lu-bu-indomitable-titan-hvn1e",
+	"lu-bu-wrath-incarnate-hvn1e","lu-bu-indomitable-titan-hvn1e-cur","lu-bu-wrath-incarnate-hvn1e-cur",
+	"fabled-azurite-fatestone-rec-hvf","seiryuu-azure-dragon-rec-hvf","fabled-azurite-fatestone-p25",
+	"seiryuu-azure-dragon-p25","fabled-azurite-fatestone-hvn1e-csr","seiryuu-azure-dragon-hvn1e-csr"
+]
+const TRANSFORM_PAIRS := {
+	"huaji-of-heavens-rise-hvn1e": "huaji-of-abyssal-fall-hvn1e",
+	"huaji-of-abyssal-fall-hvn1e": "huaji-of-heavens-rise-hvn1e",
+
+	"fatestone-of-balance-hvn": "woodland-shoats-hvn",
+	"woodland-shoats-hvn": "fatestone-of-balance-hvn",
+
+	"fatestone-of-progress-hvn": "airborne-squirrel-hvn",
+	"airborne-squirrel-hvn": "fatestone-of-progress-hvn",
+
+	"fluvial-fatestone-hvn": "mocking-otter-hvn",
+	"mocking-otter-hvn": "fluvial-fatestone-hvn",
+
+	"cyclonic-fatestone-hvn": "windstalker-wolf-hvn",
+	"windstalker-wolf-hvn": "cyclonic-fatestone-hvn",
+
+	"wildgrowth-fatestone-hvn": "elder-mandrill-hvn",
+	"elder-mandrill-hvn": "wildgrowth-fatestone-hvn",
+
+	"companion-fatestone-rec-hvf": "fatebound-caracal-rec-hvf",
+	"fatebound-caracal-rec-hvf": "companion-fatestone-rec-hvf",
+
+	"companion-fatestone-p25": "fatebound-caracal-p25",
+	"fatebound-caracal-p25": "companion-fatestone-p25",
+
+	"fatestone-of-revelations-rec-hvf": "young-wyrmling-rec-hvf",
+	"young-wyrmling-rec-hvf": "fatestone-of-revelations-rec-hvf",
+
+	"fatestone-of-revelations-p25": "young-wyrmling-p25",
+	"young-wyrmling-p25": "fatestone-of-revelations-p25",
+
+	"submerged-fatestone-hvn": "commanding-sea-titan-hvn",
+	"commanding-sea-titan-hvn": "submerged-fatestone-hvn",
+
+	"fatestone-of-unrelenting-rec-hvf": "cheetah-of-bound-fury-rec-hvf",
+	"cheetah-of-bound-fury-rec-hvf": "fatestone-of-unrelenting-rec-hvf",
+
+	"fatestone-of-unrelenting-p25": "cheetah-of-bound-fury-p25",
+	"cheetah-of-bound-fury-p25": "fatestone-of-unrelenting-p25",
+
+	"lavaplume-fatestone-rec-hvf": "firebird-trailblazer-rec-hvf",
+	"firebird-trailblazer-rec-hvf": "lavaplume-fatestone-rec-hvf",
+
+	"lavaplume-fatestone-p25": "firebird-trailblazer-p25",
+	"firebird-trailblazer-p25": "lavaplume-fatestone-p25",
+
+	"idle-fatestone-hvn": "bolstered-boar-hvn",
+	"bolstered-boar-hvn": "idle-fatestone-hvn",
+
+	"coiled-fatestone-hvn": "serpentine-judicator-hvn",
+	"serpentine-judicator-hvn": "coiled-fatestone-hvn",
+
+	"pelagic-fatestone-hvn": "slick-torrentrider-hvn",
+	"slick-torrentrider-hvn": "pelagic-fatestone-hvn",
+
+	"beseeched-fatestone-hvn": "daunting-panda-hvn",
+	"daunting-panda-hvn": "beseeched-fatestone-hvn",
+
+	"craggy-fatestone-rec-hvf": "obstinate-cragback-rec-hvf",
+	"obstinate-cragback-rec-hvf": "craggy-fatestone-rec-hvf",
+
+	"craggy-fatestone-p25": "obstinate-cragback-p25",
+	"obstinate-cragback-p25": "craggy-fatestone-p25",
+
+	"fatestone-of-heaven-rec-hvf": "heavenly-drake-rec-hvf",
+	"heavenly-drake-rec-hvf": "fatestone-of-heaven-rec-hvf",
+
+	"fatestone-of-heaven-p25": "heavenly-drake-p25",
+	"heavenly-drake-p25": "fatestone-of-heaven-p25",
+
+	"fabled-ruby-fatestone-hvn1e": "suzaku-vermillion-phoenix-hvn1e",
+	"suzaku-vermillion-phoenix-hvn1e": "fabled-ruby-fatestone-hvn1e",
+
+	"fabled-ruby-fatestone-hvn1e-csr": "suzaku-vermillion-phoenix-hvn1e-csr",
+	"suzaku-vermillion-phoenix-hvn1e-csr": "fabled-ruby-fatestone-hvn1e-csr",
+
+	"fabled-sapphire-fatestone-hvn1e": "genbu-black-tortoise-hvn1e",
+	"genbu-black-tortoise-hvn1e": "fabled-sapphire-fatestone-hvn1e",
+
+	"fabled-sapphire-fatestone-hvn1e-csr": "genbu-black-tortoise-hvn1e-csr",
+	"genbu-black-tortoise-hvn1e-csr": "fabled-sapphire-fatestone-hvn1e-csr",
+
+	"fabled-emerald-fatestone-hvn1e": "byakko-white-tiger-hvn1e",
+	"byakko-white-tiger-hvn1e": "fabled-emerald-fatestone-hvn1e",
+
+	"fabled-emerald-fatestone-hvn1e-csr": "byakko-white-tiger-hvn1e-csr",
+	"byakko-white-tiger-hvn1e-csr": "fabled-emerald-fatestone-hvn1e-csr",
+
+	"lu-bu-indomitable-titan-hvn1e": "lu-bu-wrath-incarnate-hvn1e",
+	"lu-bu-wrath-incarnate-hvn1e": "lu-bu-indomitable-titan-hvn1e",
+
+	"lu-bu-indomitable-titan-hvn1e-cur": "lu-bu-wrath-incarnate-hvn1e-cur",
+	"lu-bu-wrath-incarnate-hvn1e-cur": "lu-bu-indomitable-titan-hvn1e-cur",
+
+	"fabled-azurite-fatestone-rec-hvf": "seiryuu-azure-dragon-rec-hvf",
+	"seiryuu-azure-dragon-rec-hvf": "fabled-azurite-fatestone-rec-hvf",
+
+	"fabled-azurite-fatestone-p25": "seiryuu-azure-dragon-p25",
+	"seiryuu-azure-dragon-p25": "fabled-azurite-fatestone-p25",
+
+	"fabled-azurite-fatestone-hvn1e-csr": "seiryuu-azure-dragon-hvn1e-csr",
+	"seiryuu-azure-dragon-hvn1e-csr": "fabled-azurite-fatestone-hvn1e-csr"
+}
+
 func _ready() -> void:
 	if get_parent() and get_parent().has_method("connect_card_signals"):
 		get_parent().connect_card_signals(self)
@@ -42,6 +171,8 @@ func find_node_by_script(node: Node, script_path: String) -> Node:
 func _on_area_2d_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
 		if mouse_inside:
+			if is_in_graveyard() or is_in_banish():
+				return
 			var logo_nodes = get_tree().get_nodes_in_group("logo")
 			if logo_nodes.size() > 0:
 				var logo_node = logo_nodes[0]
@@ -59,11 +190,22 @@ func _on_area_2d_input_event(_viewport: Node, event: InputEvent, _shape_idx: int
 					popup_menu.add_item("Awake", 5)
 				else:
 					popup_menu.add_item("Rest", 5)
-			popup_menu.add_item("Show", 6)
-			popup_menu.add_item("Transform", 7)
-			popup_menu.add_item("Give to your opponent", 8)
+			var slug = get_slug_from_card()
+			if slug in TRANSFORMABLE_SLUGS:
+				popup_menu.add_item("Transform", 6)
+			var mouse_pos = get_global_mouse_position()
 			popup_menu.reset_size()
-			popup_menu.position = get_global_mouse_position()
+			var screen_size = get_viewport().get_visible_rect().size
+			var menu_size = popup_menu.get_contents_minimum_size()
+			if mouse_pos.x + menu_size.x > screen_size.x:
+				mouse_pos.x = screen_size.x - menu_size.x
+			if mouse_pos.x < 0:
+				mouse_pos.x = 0
+			if mouse_pos.y + menu_size.y > screen_size.y:
+				mouse_pos.y = screen_size.y - menu_size.y
+			if mouse_pos.y < 0:
+				mouse_pos.y = 0
+			popup_menu.position = mouse_pos
 			popup_menu.popup()
 
 func _on_area_2d_mouse_entered() -> void:
@@ -77,6 +219,31 @@ func _on_area_2d_mouse_exited() -> void:
 	emit_signal("hovered_off", self)
 	if is_in_main_field():
 		hide_card_info()
+
+func transform_card():
+	var slug = get_slug_from_card()
+	if slug == "" or not TRANSFORM_PAIRS.has(slug):
+		return
+	var new_slug = TRANSFORM_PAIRS[slug]
+	set_meta("slug", new_slug)
+	var card_image_path = "res://Assets/Grand Archive/Card Images/" + new_slug + ".png"
+	if ResourceLoader.exists(card_image_path):
+		$CardImage.texture = load(card_image_path)
+	if has_node("AnimationPlayer"):
+		var anim: AnimationPlayer = $AnimationPlayer
+		if anim.has_animation("card_flip"):
+			anim.play("card_flip")
+	if is_in_main_field() and current_field:
+		if current_field.has_method("is_champion_card") and current_field.is_champion_card(self):
+			if current_field.current_champion_card and current_field.current_champion_card != self:
+				current_field.remove_previous_champions()
+			current_field.current_champion_card = self
+			global_position = current_field.global_position
+			z_index = 400
+	if card_information_reference and mouse_inside:
+		hide_card_info()
+		show_card_info()
+		card_information_reference.show_card_preview(self)
 
 func show_card_info():
 	if not card_information_reference:
@@ -170,9 +337,7 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 		3: print("Go to TD selected")
 		4: print("Go to BD selected")
 		5: if is_in_main_field(): rotate_card()
-		6: print("Show selected")
-		7: print("Transform selected")
-		8: print("Give to your opponent")
+		6: transform_card()
 
 func rotate_card():
 	if not is_in_main_field():

--- a/Scripts/CardInformation.gd
+++ b/Scripts/CardInformation.gd
@@ -30,7 +30,8 @@ func _process(_delta: float) -> void:
 		return
 	var current_hovered_card = card_manager_reference.last_hovered_card
 	if current_hovered_card and is_instance_valid(current_hovered_card):
-		if current_hovered_card != last_displayed_card:
+		var current_slug = get_slug_from_card(current_hovered_card)
+		if current_hovered_card != last_displayed_card or current_slug != current_displayed_slug:
 			show_card_preview(current_hovered_card)
 			last_displayed_card = current_hovered_card
 


### PR DESCRIPTION
Introduces card transformation support by defining transformable slugs and their pairs, updating the right-click popup menu to conditionally show the Transform option, and implementing the transform_card() method. Also improves popup menu positioning and updates CardInformation to refresh previews when the card's slug changes.