### PR TITLE
Improve card drag and hover interaction handling

### DIFF
--- a/Scripts/Card.gd
+++ b/Scripts/Card.gd
@@ -14,6 +14,7 @@ var is_rotated = false
 var hand_position
 var mouse_inside = false
 var was_rotated_before_drag = false
+var is_dragging = false
 var card_information_reference = null
 
 const TRANSFORMABLE_SLUGS := [
@@ -169,6 +170,8 @@ func find_node_by_script(node: Node, script_path: String) -> Node:
 	return null
 
 func _on_area_2d_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
+	if is_dragging:
+		return
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
 		if mouse_inside:
 			if is_in_graveyard() or is_in_banish():
@@ -209,7 +212,7 @@ func _on_area_2d_input_event(_viewport: Node, event: InputEvent, _shape_idx: int
 func _on_area_2d_mouse_entered() -> void:
 	mouse_inside = true
 	emit_signal("hovered", self)
-	if is_in_main_field():
+	if is_in_main_field() and not is_dragging:
 		show_card_info()
 
 func _on_area_2d_mouse_exited() -> void:
@@ -238,7 +241,7 @@ func transform_card():
 			current_field.current_champion_card = self
 			global_position = current_field.global_position
 			z_index = 400
-	if card_information_reference and mouse_inside:
+	if card_information_reference and mouse_inside and not is_dragging:
 		hide_card_info()
 		show_card_info()
 		card_information_reference.show_card_preview(self)
@@ -346,13 +349,14 @@ func rotate_card():
 		is_rotated = true
 
 func on_drag_start():
+	is_dragging = true
 	was_rotated_before_drag = is_rotated
 	rotation_degrees = original_rotation
-	if is_in_main_field():
-		hide_card_info()
-		emit_signal("hovered_off", self)
+	hide_card_info()
+	emit_signal("hovered_off", self)
 
 func on_drag_end():
+	is_dragging = false
 	is_rotated = false
 	rotation_degrees = original_rotation
 

--- a/Scripts/CardManager.gd
+++ b/Scripts/CardManager.gd
@@ -309,6 +309,9 @@ func raycast_check_at_position(pos):
 
 func handle_hover():
 	if card_being_dragged or animation_in_progress:
+		for c in connected_cards:
+			if is_instance_valid(c) and c.has_node("Area2D"):
+				c.get_node("Area2D").input_pickable = false
 		return
 	validate_references()
 	var current_card = raycast_check_for_card()
@@ -332,6 +335,9 @@ func handle_hover():
 					break
 		if current_card and is_instance_valid(current_card) and not is_card_truly_hovered(current_card):
 			current_card = null
+	for c in connected_cards:
+		if is_instance_valid(c) and c.has_node("Area2D"):
+			c.get_node("Area2D").input_pickable = (current_card != null and c == current_card)
 	if current_card != last_hovered_card:
 		if last_hovered_card and is_instance_valid(last_hovered_card):
 			if can_drag_card(last_hovered_card):
@@ -346,6 +352,10 @@ func handle_hover():
 					get_banish_slot_for_card(last_hovered_card).clear_hovered_card()
 				else:
 					last_hovered_card.z_index = base_z_index
+			if last_hovered_card.has_node("Area2D"):
+				last_hovered_card.get_node("Area2D").input_pickable = false
+			if last_hovered_card.has_method("hide_card_info"):
+				last_hovered_card.hide_card_info()
 		if current_card and is_instance_valid(current_card):
 			if can_drag_card(current_card):
 				current_card.get_parent().move_child(current_card, current_card.get_parent().get_child_count())
@@ -360,6 +370,10 @@ func handle_hover():
 					get_banish_slot_for_card(current_card).bring_card_to_front(current_card)
 				else:
 					current_card.z_index = hover_z_index
+				if current_card.has_node("Area2D"):
+					current_card.get_node("Area2D").input_pickable = true
+				if current_card.has_method("is_in_main_field") and current_card.is_in_main_field() and not current_card.get("is_dragging"):
+					current_card.show_card_info()
 		last_hovered_card = current_card
 
 func connect_card_signals(card):


### PR DESCRIPTION
Added an is_dragging flag to Card.gd to prevent hover and info display during drag operations. Updated CardManager.gd to manage Area2D input_pickable state for cards based on drag and hover status, ensuring only the appropriate card is interactable and card info is shown or hidden at the correct times.