### PR TITLE
Add face-down banish and deck view card actions

### DIFF
--- a/Scenes/90DegreesCardSlot.tscn
+++ b/Scenes/90DegreesCardSlot.tscn
@@ -17,7 +17,7 @@ collision_mask = 2
 shape = SubResource("RectangleShape2D_cm0pq")
 
 [node name="PopupMenu" type="PopupMenu" parent="."]
-size = Vector2i(100, 50)
+size = Vector2i(20, 10)
 
 [node name="BanishViewWindow" type="Window" parent="."]
 size = Vector2i(600, 142)

--- a/Scenes/CardsSlotForSingleCard.tscn
+++ b/Scenes/CardsSlotForSingleCard.tscn
@@ -17,7 +17,7 @@ collision_mask = 2
 shape = SubResource("RectangleShape2D_3muqk")
 
 [node name="PopupMenu" type="PopupMenu" parent="."]
-size = Vector2i(100, 50)
+size = Vector2i(20, 10)
 
 [node name="GraveyardViewWindow" type="Window" parent="."]
 size = Vector2i(600, 142)

--- a/Scenes/mat_deck.tscn
+++ b/Scenes/mat_deck.tscn
@@ -20,7 +20,7 @@ collision_mask = 16
 shape = SubResource("RectangleShape2D_4n42c")
 
 [node name="PopupMenu" type="PopupMenu" parent="."]
-size = Vector2i(100, 50)
+size = Vector2i(20, 10)
 
 [node name="MAT_DECK_VIEW_WINDOW" type="Window" parent="."]
 size = Vector2i(600, 142)

--- a/Scripts/CardManager.gd
+++ b/Scripts/CardManager.gd
@@ -153,11 +153,9 @@ func finish_drag():
 		elif card_slot_found.name == "CardsSlotForSignleCard" or card_slot_found.name == "GRAVEYARD":
 			card_slot_found.add_card_to_slot(card_being_dragged)
 			card_being_dragged.scale = normal_scale
-			card_being_dragged.z_index = base_z_index
 		elif card_slot_found.name == "90DegreesCardSlot" or card_slot_found.name == "BANISH":
 			card_slot_found.add_card_to_slot(card_being_dragged)
 			card_being_dragged.scale = normal_scale
-			card_being_dragged.z_index = base_z_index
 		else:
 			card_being_dragged.z_index = base_z_index + card_counter
 			card_counter += 1

--- a/Scripts/GA_DECK.gd
+++ b/Scripts/GA_DECK.gd
@@ -5,6 +5,7 @@ var player_deck = ["fabled-ruby-fatestone-hvn1e","excalibur-reflected-edge-dtr1e
 
 var card_database_reference
 const CARD_SCENE_PATH = "res://Scenes/Card.tscn"
+var selected_card_slug: String = ""
 
 @onready var context_menu = $PopupMenu
 @onready var deck_view_window = $DeckViewWindow
@@ -26,6 +27,7 @@ func setup_context_menu():
 func setup_deck_view():
 	deck_view_window.close_requested.connect(_on_deck_view_close)
 	deck_view_window.hide()
+	$DeckViewWindow/PopupMenu.id_pressed.connect(_on_deck_view_popup_menu_pressed)
 
 func _on_area_2d_input_event(_viewport, event, _shape_idx):
 	if event is InputEventMouseButton:
@@ -67,17 +69,48 @@ func create_card_display(card_name: String):
 	card_display.request_popup_menu.connect(_on_card_display_popup_menu)
 	return card_display
 
-func _on_card_display_popup_menu(_slug):
+func _on_card_display_popup_menu(slug):
+	selected_card_slug = slug
 	var popup_menu = $DeckViewWindow/PopupMenu
 	popup_menu.clear()
-	popup_menu.add_item("test5")
-	popup_menu.add_item("test6")
+	popup_menu.add_item("Go Top Deck", 0)
+	popup_menu.add_item("Go Bottom Deck", 1)
 	popup_menu.popup(Rect2(get_viewport().get_mouse_position(), Vector2(0, 0)))
+
+func _on_deck_view_popup_menu_pressed(id):
+	match id:
+		0: move_card_to_top()
+		1: move_card_to_bottom()
+
+func move_card_to_top():
+	if selected_card_slug == "":
+		return
+	var card_index = player_deck.find(selected_card_slug)
+	if card_index == -1:
+		return
+	var card_name = player_deck[card_index]
+	player_deck.remove_at(card_index)
+	player_deck.insert(0, card_name)
+	update_deck_view()
+	selected_card_slug = ""
+
+func move_card_to_bottom():
+	if selected_card_slug == "":
+		return
+	var card_index = player_deck.find(selected_card_slug)
+	if card_index == -1:
+		return
+	var card_name = player_deck[card_index]
+	player_deck.remove_at(card_index)
+	player_deck.append(card_name)
+	update_deck_view()
+	selected_card_slug = ""
 
 func _on_deck_view_close():
 	deck_view_window.hide()
 	if has_node("Sprite2D"):
 		$Sprite2D.modulate = Color(1, 1, 1, 1)
+	selected_card_slug = ""
 
 func shuffle_deck():
 	player_deck.shuffle()

--- a/Scripts/MAT_DECK.gd
+++ b/Scripts/MAT_DECK.gd
@@ -2,10 +2,8 @@ extends Node2D
 
 var player_deck = ["alice-golden-queen-dtr1e-cur","aetheric-calibration-dtrsd","alice-golden-queen-dtr","academy-guide-p24", "absolving-flames-amb","acolyte-of-cultivation-amb","acolyte-of-cultivation-amb"
 ,"suzaku-vermillion-phoenix-hvn1e-csr","acolyte-of-cultivation-amb","arcane-disposition-doap","arthur-young-heir-evp","suzaku-vermillion-phoenix-hvn1e"]
-
 var card_database_reference
 const CARD_SCENE_PATH = "res://Scenes/Card.tscn"
-
 @onready var context_menu = $PopupMenu
 @onready var deck_view_window = $MAT_DECK_VIEW_WINDOW
 @onready var grid_container = $MAT_DECK_VIEW_WINDOW/ScrollContainer/GridContainer
@@ -18,7 +16,7 @@ func _ready() -> void:
 	$Area2D.input_event.connect(_on_area_2d_input_event)
 
 func setup_context_menu():
-	context_menu.add_item("View Deck", 0)
+	context_menu.add_item("View Material Deck", 0)
 	context_menu.id_pressed.connect(_on_context_menu_pressed)
 
 func setup_deck_view():
@@ -33,7 +31,7 @@ func _on_area_2d_input_event(_viewport, event, _shape_idx):
 
 func _on_context_menu_pressed(id):
 	match id:
-		0:view_deck()
+		0: view_deck()
 
 func view_deck():
 	show_deck_view()
@@ -58,15 +56,7 @@ func create_card_display(card_name: String):
 	var card_display = card_display_scene.instantiate()
 	card_display.set_meta("slug", card_name)
 	card_display.set_meta("zone", "mat_deck")
-	card_display.request_popup_menu.connect(_on_card_display_popup_menu)
 	return card_display
-
-func _on_card_display_popup_menu(_slug):
-	var popup_menu = $MAT_DECK_VIEW_WINDOW/PopupMenu
-	popup_menu.clear()
-	popup_menu.add_item("test7")
-	popup_menu.add_item("test8")
-	popup_menu.popup(Rect2(get_viewport().get_mouse_position(), Vector2(0, 0)))
 
 func _on_deck_view_close():
 	deck_view_window.hide()

--- a/Scripts/SingleCardSlot.gd
+++ b/Scripts/SingleCardSlot.gd
@@ -90,9 +90,3 @@ func remove_card_from_slot(card):
 
 func get_top_card():
 	return null
-
-#func bring_card_to_front(card):
-	#pass
-#
-#func clear_hovered_card():
-	#pass


### PR DESCRIPTION
Implemented the ability to flip cards face-down in the banish zone and updated the banish view to visually reflect face-down state. Added context menu actions in deck views to move cards to the top or bottom of the deck. Refactored z-index handling for cards in banish, improved popup menu handling, and made minor UI adjustments to popup menu sizes.