### PR TITLE
Add deck and banish actions to card slot popups

### DIFF
--- a/Scripts/90DegreesCardSlot.gd
+++ b/Scripts/90DegreesCardSlot.gd
@@ -70,11 +70,15 @@ func _on_card_display_popup_menu(slug):
 	var popup_menu = $BanishViewWindow/PopupMenu
 	popup_menu.clear()
 	popup_menu.add_item("Flip", 0)
+	popup_menu.add_item("To Top Deck", 1)
+	popup_menu.add_item("To Bottom Deck", 2)
 	popup_menu.popup(Rect2(get_viewport().get_mouse_position(), Vector2(0, 0)))
 
 func _on_banish_view_popup_menu_pressed(id):
 	match id:
 		0: flip_card()
+		1: go_to_top_deck()
+		2: go_to_bottom_deck()
 
 func flip_card():
 	if selected_card_slug == "":
@@ -89,13 +93,60 @@ func flip_card():
 		return
 	var card_image = target_card.get_node_or_null("CardImage")
 	var card_image_back = target_card.get_node_or_null("CardImageBack")
-	
 	if not card_image or not card_image_back:
 		return
 	if card_image.visible:
 		show_card_back(target_card)
 	else:
 		show_card_front(target_card)
+	if banish_view_window.visible:
+		update_deck_view()
+	selected_card_slug = ""
+
+func go_to_top_deck():
+	if selected_card_slug == "":
+		return
+	var deck_nodes = get_tree().get_nodes_in_group("deck_zones")
+	if deck_nodes.size() == 0:
+		return
+	var deck_node = deck_nodes[0]
+	if not deck_node.has_method("add_to_top"):
+		return
+	var target_card = null
+	for card in cards_in_banish:
+		var card_slug = card.get_meta("slug") if card.has_meta("slug") else (card.card_name if card.has_method("card_name") else card.name)
+		if card_slug == selected_card_slug:
+			target_card = card
+			break
+	if not target_card:
+		return
+	remove_card_from_slot(target_card)
+	target_card.queue_free()
+	deck_node.add_to_top(selected_card_slug)
+	if banish_view_window.visible:
+		update_deck_view()
+	selected_card_slug = ""
+
+func go_to_bottom_deck():
+	if selected_card_slug == "":
+		return
+	var deck_nodes = get_tree().get_nodes_in_group("deck_zones")
+	if deck_nodes.size() == 0:
+		return
+	var deck_node = deck_nodes[0]
+	if not deck_node.has_method("add_to_bottom"):
+		return
+	var target_card = null
+	for card in cards_in_banish:
+		var card_slug = card.get_meta("slug") if card.has_meta("slug") else (card.card_name if card.has_method("card_name") else card.name)
+		if card_slug == selected_card_slug:
+			target_card = card
+			break
+	if not target_card:
+		return
+	remove_card_from_slot(target_card)
+	target_card.queue_free()
+	deck_node.add_to_bottom(selected_card_slug)
 	if banish_view_window.visible:
 		update_deck_view()
 	selected_card_slug = ""

--- a/Scripts/Card.gd
+++ b/Scripts/Card.gd
@@ -184,7 +184,7 @@ func _on_area_2d_input_event(_viewport: Node, event: InputEvent, _shape_idx: int
 					apply_logo_status_to_self(logo_node)
 					return
 			popup_menu.clear()
-			popup_menu.add_item("Go to Banish Face Down", 1)
+			popup_menu.add_item("Banish Face Down", 1)
 			popup_menu.add_item("Go to Top Deck", 2)
 			popup_menu.add_item("Go to Bottom Deck", 3)
 			if is_in_main_field():
@@ -232,6 +232,8 @@ func transform_card():
 	var card_image_path = "res://Assets/Grand Archive/Card Images/" + new_slug + ".png"
 	if ResourceLoader.exists(card_image_path):
 		$CardImage.texture = load(card_image_path)
+	if current_field and current_field.has_method("notify_card_transformed"):
+		current_field.notify_card_transformed(self)
 	if has_node("AnimationPlayer"):
 		var anim: AnimationPlayer = $AnimationPlayer
 		if anim.has_animation("card_flip"):
@@ -526,10 +528,10 @@ func go_to_banish_face_down():
 			current_field.remove_card_from_slot(self)
 	if banish_node.has_method("add_card_to_slot"):
 		banish_node.add_card_to_slot(self)
-	if has_node("AnimationPlayer"):
-		var anim: AnimationPlayer = $AnimationPlayer
-		if anim and anim.has_animation("card_flip"):
-			anim.play("card_flip")
+	#if has_node("AnimationPlayer"):
+		#var anim: AnimationPlayer = $AnimationPlayer
+		#if anim and anim.has_animation("card_flip"):
+			#anim.play("card_flip")
 	if banish_node.has_method("show_card_back"):
 		banish_node.show_card_back(self)
 

--- a/Scripts/Main_Field.gd
+++ b/Scripts/Main_Field.gd
@@ -42,6 +42,10 @@ func add_card_to_field(card, position = null):
 		if position != null:
 			card.global_position = position
 
+func notify_card_transformed(card):
+	if card == current_champion_card and not is_champion_card(card):
+		current_champion_card = null
+
 func remove_previous_champions():
 	if current_champion_card and is_instance_valid(current_champion_card):
 		cards_in_field.erase(current_champion_card)

--- a/Scripts/SingleCardSlot.gd
+++ b/Scripts/SingleCardSlot.gd
@@ -3,6 +3,8 @@ extends Node2D
 var cards_in_graveyard = []
 var card_in_slot = false
 var base_z_index = 0
+var selected_card_slug: String = ""
+
 @onready var context_menu = $PopupMenu
 @onready var graveyard_view_window = $GraveyardViewWindow
 @onready var grid_container = $GraveyardViewWindow/ScrollContainer/GridContainer
@@ -14,6 +16,7 @@ func _ready() -> void:
 	setup_deck_view()
 	if area2d and not area2d.input_event.is_connected(_on_area_2d_input_event):
 		area2d.input_event.connect(_on_area_2d_input_event)
+	$GraveyardViewWindow/PopupMenu.id_pressed.connect(_on_graveyard_view_popup_menu_pressed)
 
 func update_deck_view():
 	for child in grid_container.get_children():
@@ -54,12 +57,94 @@ func create_card_display(card_name: String):
 	card_display.request_popup_menu.connect(_on_card_display_popup_menu)
 	return card_display
 
-func _on_card_display_popup_menu(_slug):
+func _on_card_display_popup_menu(slug):
+	selected_card_slug = slug
 	var popup_menu = $GraveyardViewWindow/PopupMenu
 	popup_menu.clear()
-	popup_menu.add_item("test1")
-	popup_menu.add_item("test2")
+	popup_menu.add_item("Banish Face Down", 0)
+	popup_menu.add_item("To Top Deck", 1)
+	popup_menu.add_item("To Bottom Deck", 2)
 	popup_menu.popup(Rect2(get_viewport().get_mouse_position(), Vector2(0, 0)))
+
+func _on_graveyard_view_popup_menu_pressed(id):
+	match id:
+		0: go_to_banish_face_down()
+		1: go_to_top_deck()
+		2: go_to_bottom_deck()
+
+func go_to_banish_face_down():
+	if selected_card_slug == "":
+		return
+	var target_card = null
+	for card in cards_in_graveyard:
+		var card_slug = card.get_meta("slug") if card.has_meta("slug") else (card.card_name if card.has_method("card_name") else card.name)
+		if card_slug == selected_card_slug:
+			target_card = card
+			break
+	if not target_card:
+		return
+	var scene = get_tree().get_current_scene()
+	if scene == null:
+		return
+	var banish_node = scene.find_child("BANISH", true, false)
+	if banish_node == null:
+		return
+	remove_card_from_slot(target_card)
+	if banish_node.has_method("add_card_to_slot"):
+		banish_node.add_card_to_slot(target_card)
+	if banish_node.has_method("show_card_back"):
+		banish_node.show_card_back(target_card)
+	if graveyard_view_window.visible:
+		update_deck_view()
+	selected_card_slug = ""
+
+func go_to_top_deck():
+	if selected_card_slug == "":
+		return
+	var deck_nodes = get_tree().get_nodes_in_group("deck_zones")
+	if deck_nodes.size() == 0:
+		return
+	var deck_node = deck_nodes[0]
+	if not deck_node.has_method("add_to_top"):
+		return
+	var target_card = null
+	for card in cards_in_graveyard:
+		var card_slug = card.get_meta("slug") if card.has_meta("slug") else (card.card_name if card.has_method("card_name") else card.name)
+		if card_slug == selected_card_slug:
+			target_card = card
+			break
+	if not target_card:
+		return
+	remove_card_from_slot(target_card)
+	target_card.queue_free()
+	deck_node.add_to_top(selected_card_slug)
+	if graveyard_view_window.visible:
+		update_deck_view()
+	selected_card_slug = ""
+
+func go_to_bottom_deck():
+	if selected_card_slug == "":
+		return
+	var deck_nodes = get_tree().get_nodes_in_group("deck_zones")
+	if deck_nodes.size() == 0:
+		return
+	var deck_node = deck_nodes[0]
+	if not deck_node.has_method("add_to_bottom"):
+		return
+	var target_card = null
+	for card in cards_in_graveyard:
+		var card_slug = card.get_meta("slug") if card.has_meta("slug") else (card.card_name if card.has_method("card_name") else card.name)
+		if card_slug == selected_card_slug:
+			target_card = card
+			break
+	if not target_card:
+		return
+	remove_card_from_slot(target_card)
+	target_card.queue_free()
+	deck_node.add_to_bottom(selected_card_slug)
+	if graveyard_view_window.visible:
+		update_deck_view()
+	selected_card_slug = ""
 
 func show_deck_view():
 	update_deck_view()
@@ -69,6 +154,7 @@ func show_deck_view():
 
 func _on_deck_view_close():
 	graveyard_view_window.hide()
+	selected_card_slug = ""
 
 func add_card_to_slot(card):
 	if card.has_method("set_current_field"):
@@ -87,6 +173,8 @@ func remove_card_from_slot(card):
 		cards_in_graveyard.erase(card)
 		if cards_in_graveyard.is_empty():
 			card_in_slot = false
+		if graveyard_view_window.visible:
+			update_deck_view()
 
 func get_top_card():
 	return null


### PR DESCRIPTION
Enhanced 90DegreesCardSlot and SingleCardSlot to allow moving cards to top/bottom of deck or banishing face down via popup menus. Updated Card.gd to rename a menu item and notify Main_Field when a card is transformed, ensuring champion tracking is accurate. These changes improve card management and user interaction in the card game interface.