### PR TITLE
Fix card drag reset and deck view updates

### DIFF
--- a/Scripts/CardDisplay.gd
+++ b/Scripts/CardDisplay.gd
@@ -71,6 +71,10 @@ func start_drag_from_grid():
 			card_manager.set_dragged_from_grid_info(card_slug, zone, self)
 			update_grid_immediately()
 			emit_signal("card_drag_started", self)
+		card_slug = ""
+		card_image_path = ""
+		texture_rect.texture = null
+		custom_minimum_size = Vector2.ZERO
 
 func finish_drag_from_grid():
 	if not is_holding or not dragged_card:
@@ -103,7 +107,7 @@ func create_real_card_for_drag():
 	real_card.set_meta("slug", card_slug)
 	real_card.set_meta("is_dragged_from_grid", true)
 	real_card.set_meta("original_zone", zone)
-	var card_image_path = "res://Assets/Grand Archive/Card Images/" + card_slug + ".png"
+	card_image_path = "res://Assets/Grand Archive/Card Images/" + card_slug + ".png"
 	if ResourceLoader.exists(card_image_path):
 		real_card.get_node("CardImage").texture = load(card_image_path)
 		real_card.get_node("CardImage").visible = true

--- a/Scripts/MAT_DECK.gd
+++ b/Scripts/MAT_DECK.gd
@@ -44,6 +44,9 @@ func update_deck_view():
 	for card_name in player_deck:
 		var card_display = create_card_display(card_name)
 		grid_container.add_child(card_display)
+	if player_deck.size() == 0:
+		$Area2D/CollisionShape2D.disabled = true
+		$Sprite2D.visible = false
 
 func show_deck_view():
 	deck_view_window.popup_centered()


### PR DESCRIPTION
### **User description**
Resets card display properties after dragging from grid to prevent stale data. Disables deck area and hides sprite when the deck is empty in MAT_DECK.gd to improve UI feedback.


___

### **PR Type**
Bug fix


___

### **Description**
- Reset card display properties after grid drag

- Disable deck area when empty

- Hide deck sprite when no cards

- Fix card image path variable scope


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Card Drag Start"] --> B["Reset Display Properties"]
  B --> C["Clear Card Data"]
  D["Deck Update"] --> E["Check Empty Deck"]
  E --> F["Disable Area & Hide Sprite"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CardDisplay.gd</strong><dd><code>Reset card properties after drag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Scripts/CardDisplay.gd

<ul><li>Reset <code>card_slug</code>, <code>card_image_path</code>, and texture after drag start<br> <li> Clear custom minimum size to prevent stale display data<br> <li> Fix variable scope by removing local declaration of <code>card_image_path</code></ul>


</details>


  </td>
  <td><a href="https://github.com/dedoZvezdi/Project_AnamoN/pull/123/files#diff-e5c9e10b5f5eda77fde300a2b426d6a33b8bc0ac42b0c00b3658e164ba9d93b2">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MAT_DECK.gd</strong><dd><code>Handle empty deck UI state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Scripts/MAT_DECK.gd

<ul><li>Disable collision shape when deck is empty<br> <li> Hide sprite when no cards in deck<br> <li> Improve UI feedback for empty deck state</ul>


</details>


  </td>
  <td><a href="https://github.com/dedoZvezdi/Project_AnamoN/pull/123/files#diff-baac3a7621f268de0d5ae65883bb58d15ebbe685d005fc1f03d8640ecbb06e2d">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

