### PR TITLE
Update drag logic to skip grid update for logo tokens

### DIFF
--- a/Scripts/CardDisplay.gd
+++ b/Scripts/CardDisplay.gd
@@ -69,12 +69,13 @@ func start_drag_from_grid():
 		if card_manager and card_manager.has_method("start_drag"):
 			card_manager.start_drag(real_card)
 			card_manager.set_dragged_from_grid_info(card_slug, zone, self)
-			update_grid_immediately()
-			emit_signal("card_drag_started", self)
-		#card_slug = ""
-		card_image_path = ""
-		texture_rect.texture = null
-		custom_minimum_size = Vector2.ZERO
+			if zone != "logo_tokens":
+				update_grid_immediately()
+				emit_signal("card_drag_started", self)
+				#card_slug = ""
+				card_image_path = ""
+				texture_rect.texture = null
+				custom_minimum_size = Vector2.ZERO
 
 func finish_drag_from_grid():
 	if not is_holding or not dragged_card:


### PR DESCRIPTION
### **User description**
Modified start_drag_from_grid to only call update_grid_immediately and emit card_drag_started if the zone is not 'logo_tokens'. This prevents unnecessary grid updates and signal emissions when dragging logo tokens.


___

### **PR Type**
Enhancement


___

### **Description**
- Skip grid updates for logo token drags

- Prevent unnecessary signal emissions for logo tokens

- Optimize drag performance for specific zone


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["start_drag_from_grid()"] --> B["Check zone type"]
  B --> C["zone == 'logo_tokens'?"]
  C -->|No| D["Update grid & emit signals"]
  C -->|Yes| E["Skip updates"]
  D --> F["Normal drag behavior"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CardDisplay.gd</strong><dd><code>Conditional grid updates for logo tokens</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Scripts/CardDisplay.gd

<ul><li>Added conditional check for <code>zone != "logo_tokens"</code><br> <li> Wrapped grid update and signal emission in condition<br> <li> Moved card cleanup code inside conditional block</ul>


</details>


  </td>
  <td><a href="https://github.com/dedoZvezdi/Project_AnamoN/pull/124/files#diff-e5c9e10b5f5eda77fde300a2b426d6a33b8bc0ac42b0c00b3658e164ba9d93b2">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

