### PR TITLE
Add token card handling and destruction logic

### DIFF
--- a/Scripts/90DegreesCardSlot.gd
+++ b/Scripts/90DegreesCardSlot.gd
@@ -192,6 +192,12 @@ func _on_deck_view_close():
 	selected_card_slug = ""
 
 func add_card_to_slot(card):
+	if not card or not is_instance_valid(card):
+		return
+	if card.has_method("is_token") and card.is_token():
+		if card.has_method("destroy_token"):
+			card.destroy_token()
+		return
 	if card.has_method("set_current_field"):
 		card.set_current_field(self)
 	cards_in_banish.append(card)

--- a/Scripts/Logo.gd
+++ b/Scripts/Logo.gd
@@ -34,6 +34,25 @@ var add_marker_dialog: AcceptDialog
 var marker_name_input: LineEdit
 var add_counter_dialog: AcceptDialog
 var counter_name_input: LineEdit
+var token_slugs : Array = [
+	"acerbica-hvn","astral-shard-dtr","astral-shard-dtrsd","atmos-shield-mrc",
+	"atmos-shield-sp2","aurousteel-greatsword-alc","aurousteel-greatsword-alcsd","aurousteel-greatsword-sp2",
+	"automaton-drone-alc","automaton-drone-alcsd","automaton-drone-mrc","automaton-drone-sp2",
+	"baihua-hvn","baihua-rec-idy","blightroot-alc","blightroot-alcsd",
+	"blightroot-mrc","blightroot-sp2","direwolf-hvn","fledgling-hvn",
+	"floodbloom-hvn","floodbloom-rec-idy","flowerbud-hvn","flowerbud-rec-idy",
+	"fraysia-alc","fraysia-alcsd","fraysia-mrc","fraysia-sp2","lycoria-hvn",
+	"lycoria-rec-idy","manaroot-alc","manaroot-alcsd","manaroot-mrc","manaroot-sp2",
+	"nightshade-hvn","nightshade-rec-idy","obelisk-of-armaments-alc","obelisk-of-armaments-alcsd",
+	"obelisk-of-armaments-sp2","obelisk-of-fabrication-alc","obelisk-of-fabrication-alcsd",
+	"obelisk-of-fabrication-sp2","obelisk-of-protection-alc","obelisk-of-protection-alcsd","obelisk-of-protection-sp2",
+	"ominous-shadow-evp","ominous-shadow-mrc","ominous-shadow-rec-shd",
+	"ominous-shadow-sp2","powercell-mrc-a","powercell-mrc-b","powercell-sp2",
+	"razorvine-alc","razorvine-alcsd","razorvine-mrc","razorvine-sp2",
+	"silvershine-alc","silvershine-alcsd","silvershine-mrc","silvershine-sp2",
+	"spirit-shard-mrc","spirit-shard-sp2","springleaf-alc","springleaf-alcsd",
+	"springleaf-mrc","springleaf-sp2","vacuous-servant-dtr","washuru-hvn"
+]
 
 func _ready():
 	add_to_group("logo")
@@ -642,24 +661,6 @@ func _on_popup_menu_id_pressed(id):
 func populate_tokens():
 	for child in grid_container.get_children():
 		child.queue_free()
-	var token_slugs = [
-	"acerbica-hvn","astral-shard-dtr","astral-shard-dtrsd","atmos-shield-mrc",
-	"atmos-shield-sp2","aurousteel-greatsword-alc","aurousteel-greatsword-alcsd","aurousteel-greatsword-sp2",
-	"automaton-drone-alc","automaton-drone-alcsd","automaton-drone-mrc","automaton-drone-sp2",
-	"baihua-hvn","baihua-rec-idy","blightroot-alc","blightroot-alcsd",
-	"blightroot-mrc","blightroot-sp2","direwolf-hvn","fledgling-hvn",
-	"floodbloom-hvn","floodbloom-rec-idy","flowerbud-hvn","flowerbud-rec-idy",
-	"fraysia-alc","fraysia-alcsd","fraysia-mrc","fraysia-sp2","lycoria-hvn",
-	"lycoria-rec-idy","manaroot-alc","manaroot-alcsd","manaroot-mrc","manaroot-sp2",
-	"nightshade-hvn","nightshade-rec-idy","obelisk-of-armaments-alc","obelisk-of-armaments-alcsd",
-	"obelisk-of-armaments-sp2","obelisk-of-fabrication-alc","obelisk-of-fabrication-alcsd",
-	"obelisk-of-fabrication-sp2","obelisk-of-protection-alc","obelisk-of-protection-alcsd","obelisk-of-protection-sp2",
-	"ominous-shadow-evp","ominous-shadow-mrc","ominous-shadow-rec-shd",
-	"ominous-shadow-sp2","powercell-mrc-a","powercell-mrc-b","powercell-sp2",
-	"razorvine-alc","razorvine-alcsd","razorvine-mrc","razorvine-sp2",
-	"silvershine-alc","silvershine-alcsd","silvershine-mrc","silvershine-sp2",
-	"spirit-shard-mrc","spirit-shard-sp2","springleaf-alc","springleaf-alcsd",
-	"springleaf-mrc","springleaf-sp2","vacuous-servant-dtr","washuru-hvn"]
 	token_slugs.sort()
 	for slug in token_slugs:
 		var card_display = create_card_display(slug)

--- a/Scripts/MemoryCardsSlot.gd
+++ b/Scripts/MemoryCardsSlot.gd
@@ -35,6 +35,12 @@ func _on_global_lmb_released():
 	reset_card_colors()
 
 func add_card_to_memory(card):
+	if not card or not is_instance_valid(card):
+		return
+	if card.has_method("is_token") and card.is_token():
+		if card.has_method("destroy_token"):
+			card.destroy_token()
+		return
 	if card.has_method("set_current_field"):
 		card.set_current_field(self)
 
@@ -109,6 +115,12 @@ func show_card_front(card):
 			card_image.texture = card.get_meta("original_card_texture")
 
 func insert_card_at_position(card, index):
+	if not card or not is_instance_valid(card):
+		return
+	if card.has_method("is_token") and card.is_token():
+		if card.has_method("destroy_token"):
+			card.destroy_token()
+		return
 	if card.has_method("set_current_field"):
 		card.set_current_field(self)
 	if index < 0:
@@ -119,6 +131,12 @@ func insert_card_at_position(card, index):
 	arrange_cards_symmetrically()
 
 func add_card_near_position(card, target_x_position):
+	if not card or not is_instance_valid(card):
+		return
+	if card.has_method("is_token") and card.is_token():
+		if card.has_method("destroy_token"):
+			card.destroy_token()
+		return
 	var slot_width = get_slot_width()
 	var slot_start = global_position.x - slot_width/2
 	var slot_end = global_position.x + slot_width/2

--- a/Scripts/PlayerHand.gd
+++ b/Scripts/PlayerHand.gd
@@ -38,6 +38,10 @@ func _exit_tree():
 func add_card_to_hand(card):
 	if not card or not is_instance_valid(card):
 		return
+	if card.has_method("is_token") and card.is_token():
+		if card.has_method("destroy_token"):
+			card.destroy_token()
+		return
 	if card.has_method("set_current_field"):
 		card.set_current_field(self)
 	if card not in player_hand:

--- a/Scripts/SingleCardSlot.gd
+++ b/Scripts/SingleCardSlot.gd
@@ -157,6 +157,12 @@ func _on_deck_view_close():
 	selected_card_slug = ""
 
 func add_card_to_slot(card):
+	if not card or not is_instance_valid(card):
+		return
+	if card.has_method("is_token") and card.is_token():
+		if card.has_method("destroy_token"):
+			card.destroy_token()
+		return
 	if card.has_method("set_current_field"):
 		card.set_current_field(self)
 	cards_in_graveyard.append(card)


### PR DESCRIPTION
Introduces checks in card slot and hand scripts to detect token cards and destroy them instead of adding them to slots or hand. Refactors token slug list in Logo.gd to a class variable for easier access. Adds is_token and destroy_token methods to Card.gd, and updates context menus to allow destroying tokens directly. This prevents tokens from being placed in invalid locations and centralizes token management.