### PR TITLE
Preserve card marks, track drag origins, and UI fixes

### DIFF
--- a/Scripts/Card.gd
+++ b/Scripts/Card.gd
@@ -94,7 +94,8 @@ func _ready() -> void:
 	if get_parent() and get_parent().has_method("connect_card_signals"):
 		get_parent().connect_card_signals(self)
 	popup_menu.id_pressed.connect(_on_PopupMenu_id_pressed)
-	popup_menu.reparent.call_deferred(get_tree().root)
+	popup_menu.add_theme_font_size_override("font_size", 40)
+	popup_menu.add_theme_constant_override("v_separation", 12)
 	area.input_event.connect(_on_area_2d_input_event)
 	find_card_information_reference()
 	if card_level_lable:
@@ -214,6 +215,8 @@ func is_shifting_currents_card() -> bool:
 	return false
 
 func _on_area_2d_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
+	if event is InputEventMouseButton and event.pressed:
+		get_viewport().set_input_as_handled()
 	if is_dragging:
 		return
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
@@ -1454,7 +1457,3 @@ func _convert_to_opponent_card_visuals(final_pos, final_rot):
 	var fix_tween = create_tween()
 	fix_tween.tween_property(new_opp_card, "rotation_degrees", final_rot, 0.2)
 	remove_from_current_position()
-
-func _exit_tree() -> void:
-	if is_instance_valid(popup_menu):
-		popup_menu.queue_free()

--- a/Scripts/CardDisplay.gd
+++ b/Scripts/CardDisplay.gd
@@ -280,6 +280,10 @@ func create_real_card_for_drag():
 	real_card.set_meta("original_zone", zone)
 	if has_meta("uuid"):
 		real_card.set_meta("uuid", get_meta("uuid"))
+	if has_meta("is_marked"):
+		real_card.set_meta("is_marked", get_meta("is_marked"))
+		if "is_marked" in real_card:
+			real_card.is_marked = get_meta("is_marked")
 	card_image_path = "res://Assets/Grand Archive/Card Images/" + card_slug + ".png"
 	if ResourceLoader.exists(card_image_path):
 		var card_image = real_card.get_node("CardImage")

--- a/Scripts/CardManager.gd
+++ b/Scripts/CardManager.gd
@@ -218,20 +218,36 @@ func start_drag(card):
 	if card.has_method("is_in_main_field") and card.is_in_main_field():
 		drag_source_was_main_field = true
 	else:
-		drag_source_was_main_field = false
+		drag_source_was_main_field = false	
+	var drag_source_was_hand = false
 	if player_hand_reference and card in player_hand_reference.player_hand:
 		player_hand_reference.dragging_card_from_hand = card
+		drag_source_was_hand = true
+	var drag_source_was_graveyard = false
+	var graveyard_slot_initial = get_graveyard_slot_for_card(card)
+	if graveyard_slot_initial:
+		drag_source_was_graveyard = true
+	var drag_source_was_banish = false
+	var banish_slot_initial = get_banish_slot_for_card(card)
+	if banish_slot_initial:
+		drag_source_was_banish = true
 	source_memory_slot = get_memory_slot_for_card(card)
+	var drag_source_was_memory = false
 	if source_memory_slot:
 		original_memory_index = source_memory_slot.cards_in_slot.find(card)
-		if "is_marked" in card:
-			drag_card_was_marked = card.is_marked
-		elif card.has_meta("is_marked") and card.get_meta("is_marked") == true:
-			drag_card_was_marked = true
-		else:
-			drag_card_was_marked = false
+		drag_source_was_memory = true
 	else:
 		original_memory_index = -1
+	card.set_meta("drag_origin_hand", drag_source_was_hand)
+	card.set_meta("drag_origin_mainfield", drag_source_was_main_field)
+	card.set_meta("drag_origin_memory", drag_source_was_memory)
+	card.set_meta("drag_origin_graveyard", drag_source_was_graveyard)
+	card.set_meta("drag_origin_banish", drag_source_was_banish)
+	if "is_marked" in card:
+		drag_card_was_marked = card.is_marked
+	elif card.has_meta("is_marked") and card.get_meta("is_marked") == true:
+		drag_card_was_marked = true
+	else:
 		drag_card_was_marked = false
 	card.get_parent().move_child(card, card.get_parent().get_child_count())
 	card.z_index = drag_z_index
@@ -459,11 +475,28 @@ func finish_drag():
 			player_hand_reference.update_hand_position()
 		player_hand_reference.clear_external_preview()
 	if card and is_instance_valid(card) and card.has_method("set_marked"):
-		var ended_in_memory = false
-		if card_slot_found and card_slot_found.name == "MEMORY":
-			ended_in_memory = true
-		if not ended_in_memory:
+		var ended_in_same_zone = false
+		if card_slot_found:
+			if card_slot_found.name == "MEMORY" and card.get_meta("drag_origin_memory") == true:
+				ended_in_same_zone = true
+			elif card_slot_found.name == "MAINFIELD" and card.get_meta("drag_origin_mainfield") == true:
+				ended_in_same_zone = true
+			elif card_slot_found.name == "GRAVEYARD" and (card.get_meta("drag_origin_graveyard") == true or (card.has_meta("is_dragged_from_grid") and card.get_meta("original_zone") == "graveyard")):
+				ended_in_same_zone = true
+			elif card_slot_found.name == "BANISH" and (card.get_meta("drag_origin_banish") == true or (card.has_meta("is_dragged_from_grid") and card.get_meta("original_zone") == "banish")):
+				ended_in_same_zone = true
+		elif not card_slot_found and player_hand_reference and card in player_hand_reference.player_hand:
+			if card.get_meta("drag_origin_hand") == true:
+				ended_in_same_zone = true
+		if not ended_in_same_zone:
 			card.set_marked(false)
+		elif drag_card_was_marked:
+			if card.has_method("can_be_marked") and card.can_be_marked():
+				card.set_marked(true)
+			if card_slot_found and card_slot_found.has_method("set_card_marked"):
+				var uuid = card.uuid if "uuid" in card else ""
+				if uuid != "":
+					card_slot_found.set_card_marked(uuid, true)
 	_reset_drag_state_vars()
 	call_deferred("force_hover_check")
 

--- a/Scripts/OpponentCard.gd
+++ b/Scripts/OpponentCard.gd
@@ -163,8 +163,6 @@ func set_current_field(field):
 	current_field = field
 
 func set_opponent_reveal_status(revealed: bool, skip_animation: bool = false):
-	if is_marked:
-		set_marked(false)
 	is_revealed_by_opponent = revealed
 	if mouse_inside:
 		if revealed:
@@ -447,6 +445,8 @@ func animate_send_to_lineage(card_node: Node, card_slug: String, card_uuid: Stri
 		final_callback.call()
 
 func _on_area_2d_input_event(_viewport, event, _shape_idx):
+	if event is InputEventMouseButton and event.pressed:
+		get_viewport().set_input_as_handled()
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
 		if is_champion_card() and is_in_main_field():
 			if event.pressed:
@@ -456,7 +456,7 @@ func _on_area_2d_input_event(_viewport, event, _shape_idx):
 				_reset_hold()
 			return
 		if event.pressed:
-			if is_in_memory_zone() or is_in_main_field():
+			if is_in_memory_zone() or is_in_main_field() or is_in_hand():
 				if can_be_marked():
 					toggle_mark()
 
@@ -466,6 +466,14 @@ func is_in_memory_zone() -> bool:
 	var parent = get_parent()
 	if parent and parent.is_in_group("memory_slots"):
 		return true
+	return false
+
+func is_in_hand() -> bool:
+	var opponent_hand_nodes = get_tree().get_nodes_in_group("opponent_hand")
+	for hand_node in opponent_hand_nodes:
+		if "opponent_hand" in hand_node:
+			if self in hand_node.opponent_hand:
+				return true
 	return false
 
 func can_be_marked() -> bool:

--- a/Scripts/OpponentHand.gd
+++ b/Scripts/OpponentHand.gd
@@ -363,17 +363,17 @@ func _on_card_visuals_changed(_card):
 	call_deferred("enforce_z_ordering")
 func reorder_by_uuids(uuid_list: Array):
 	uuid_list.reverse()
-	var revealed_map = {}
+	var tracked_map = {}
 	var hidden_pool = []
 	var hidden_map = {}
 	for card in opponent_hand:
 		if not card or not is_instance_valid(card):
 			continue
-		var is_revealed = false
-		if card.get("is_revealed_by_opponent") == true:
-			is_revealed = true
-		if is_revealed:
-			revealed_map[card.uuid] = card
+		var should_track = false
+		if card.get("is_revealed_by_opponent") == true or card.get("is_marked") == true:
+			should_track = true
+		if should_track:
+			tracked_map[card.uuid] = card
 		else:
 			hidden_pool.append(card)
 			hidden_map[card.uuid] = card
@@ -381,8 +381,8 @@ func reorder_by_uuids(uuid_list: Array):
 	new_hand.resize(uuid_list.size())
 	for i in range(uuid_list.size()):
 		var target_uuid = uuid_list[i]
-		if target_uuid in revealed_map:
-			new_hand[i] = revealed_map[target_uuid]
+		if target_uuid in tracked_map:
+			new_hand[i] = tracked_map[target_uuid]
 	var pool_index = 0
 	for i in range(new_hand.size()):
 		if new_hand[i] == null:

--- a/Scripts/PlayerHand.gd
+++ b/Scripts/PlayerHand.gd
@@ -454,15 +454,15 @@ func cleanup():
 	animation_in_progress = false
 
 func sync_hand_order():
-	var has_revealed = false
+	var should_sync = false
 	var uuid_list = []
 	for card in player_hand:
 		if card and is_instance_valid(card):
 			if "uuid" in card:
 				uuid_list.append(card.uuid)
-			if card.get("is_publicly_revealed") == true:
-				has_revealed = true
-	if has_revealed:
+			if card.get("is_publicly_revealed") == true or card.get("is_marked") == true:
+				should_sync = true
+	if should_sync:
 		var multiplayer_node = get_tree().get_root().get_node_or_null("Main")
 		if multiplayer_node and multiplayer_node.has_method("rpc"):
 			multiplayer_node.rpc("rpc_sync_hand_order", multiplayer.get_unique_id(), uuid_list)

--- a/Scripts/SingleCardSlot.gd
+++ b/Scripts/SingleCardSlot.gd
@@ -294,12 +294,10 @@ func add_card_to_slot(card, at_index: int = -1):
 			ci.visible = true
 			cib.visible = false
 	final_card.rotation = 0.0
-	
 	if at_index != -1 and at_index < cards_in_graveyard.size():
 		cards_in_graveyard.insert(at_index, final_card)
 	else:
 		cards_in_graveyard.append(final_card)
-		
 	reorder_z_indices()
 	var card_manager = get_tree().current_scene.find_child("CardManager", true, false)
 	if card_manager and card_manager.has_method("connect_card_signals"):

--- a/project.godot
+++ b/project.godot
@@ -23,8 +23,9 @@ config/icon="uid://bh4b1t4rtb1d4"
 
 [display]
 
-window/size/viewport_width=1600
+window/size/viewport_width=1920
 window/size/viewport_height=1080
+window/size/mode=3
 window/stretch/mode="canvas_items"
 window/vsync/vsync_mode=2
 


### PR DESCRIPTION
Track drag origins and preserve/restore card marked state: CardManager now records drag origin flags (hand, mainfield, memory, graveyard, banish) on cards and uses them to avoid clearing marks when a card is dropped back into its original zone; previously-marked cards are re-applied and memory/slot state is updated where applicable. Transfer marked meta when creating real drag visuals: CardDisplay forwards is_marked metadata to the real card.

Mouse/input and popup UI tweaks: Card.gd and OpponentCard.gd mark mouse button events as handled to prevent unwanted propagation; popup menu styling (font size and vertical separation) adjusted. Removed redundant popup cleanup in Card.gd.

Opponent/hand sync and ordering updates: OpponentHand and PlayerHand now consider marked cards when reordering/syncing hand state (tracked alongside revealed/publicly revealed cards). OpponentCard gained is_in_hand() helper and allows marking while in hand.

Minor fixes: whitespace cleanup in SingleCardSlot and project.godot updated default window width to 1920 and window mode set to 3.