### PR TITLE
Add Predefined counters; remove markers

### DIFF
--- a/Scenes/90DegreesCardSlot.tscn
+++ b/Scenes/90DegreesCardSlot.tscn
@@ -9,6 +9,13 @@ size = Vector2(128, 90)
 [node name="90degreesCardSlot" type="Node2D" unique_id=31231617]
 script = ExtResource("1_xluvn")
 
+[node name="RichTextLabel" type="RichTextLabel" parent="." unique_id=1793208658]
+offset_left = -40.0
+offset_top = -67.0
+offset_right = 40.0
+offset_bottom = -45.0
+horizontal_alignment = 1
+
 [node name="Area2D" type="Area2D" parent="." unique_id=7360531]
 collision_layer = 2
 collision_mask = 2

--- a/Scenes/CardInformation.tscn
+++ b/Scenes/CardInformation.tscn
@@ -53,13 +53,6 @@ offset_top = 607.0
 offset_right = 1917.0
 offset_bottom = 647.0
 
-[node name="Markers" type="RichTextLabel" parent="." unique_id=241965935]
-offset_left = 45.0
-offset_top = 195.0
-offset_right = 229.0
-offset_bottom = 379.0
-horizontal_alignment = 1
-
 [node name="Counters" type="RichTextLabel" parent="." unique_id=2105699958]
 offset_left = 45.0
 offset_top = 195.0

--- a/Scenes/Opponent_Banish.tscn
+++ b/Scenes/Opponent_Banish.tscn
@@ -9,6 +9,13 @@ size = Vector2(128, 90)
 [node name="OpponentBanish" type="Node2D" unique_id=1512681821]
 script = ExtResource("1_vxi04")
 
+[node name="RichTextLabel" type="RichTextLabel" parent="." unique_id=1380387391]
+offset_left = 578.0
+offset_top = 483.0
+offset_right = 658.0
+offset_bottom = 503.0
+horizontal_alignment = 1
+
 [node name="Area2D" type="Area2D" parent="." unique_id=2043320380]
 collision_layer = 128
 collision_mask = 128

--- a/Scripts/90DegreesCardSlot.gd
+++ b/Scripts/90DegreesCardSlot.gd
@@ -9,6 +9,9 @@ var marked_uuids : Array = []
 var hold_timer = 0.0
 var is_holding_left = false
 var progress_bar: TextureProgressBar
+var omen_count = 0
+var omen_label: Label
+var is_hovering = false
 
 @onready var banish_view_window = $BanishViewWindow
 @onready var grid_container = $BanishViewWindow/ScrollContainer/GridContainer
@@ -23,6 +26,9 @@ func _ready() -> void:
 		area2d.input_event.connect(_on_area_2d_input_event)
 	if area2d and not area2d.mouse_exited.is_connected(_on_mouse_exited):
 		area2d.mouse_exited.connect(_on_mouse_exited)
+	if area2d and not area2d.mouse_entered.is_connected(_on_mouse_entered):
+		area2d.mouse_entered.connect(_on_mouse_entered)
+	_setup_omen_label()
 	$BanishViewWindow/PopupMenu.id_pressed.connect(_on_banish_view_popup_menu_pressed)
 	_setup_progress_bar()
 
@@ -106,9 +112,59 @@ func _on_area_2d_input_event(_viewport, event, _shape_idx):
 				hold_timer = 0.0
 			else:
 				_reset_hold()
+		elif event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+			if cards_in_banish.is_empty():
+				return
+			var logo_nodes = get_tree().get_nodes_in_group("logo")
+			if logo_nodes.size() > 0:
+				var logo = logo_nodes[0]
+				if logo.has_method("has_active_status") and logo.has_active_status():
+					if logo.custom_counters.get("Omen", 0) != 0:
+						omen_count += logo.custom_counters["Omen"]
+						update_omen_label()
+						sync_omen_count()
+						logo.reset_all_status_values()
+						return
+
+func _on_mouse_entered():
+	is_hovering = true
+	update_omen_label()
 
 func _on_mouse_exited():
+	is_hovering = false
+	update_omen_label()
 	_reset_hold()
+
+func _setup_omen_label():
+	omen_label = get_node_or_null("OmenLabel")
+	if not omen_label:
+		omen_label = Label.new()
+		omen_label.name = "OmenLabel"
+		omen_label.add_theme_font_size_override("font_size", 20)
+		omen_label.z_index = 1500
+		omen_label.visible = false
+		add_child(omen_label)
+		omen_label.position = Vector2(-45, -70)
+	
+func update_omen_label():
+	if omen_label:
+		omen_label.text = "Omens : " + str(omen_count)
+		if omen_count > 0:
+			omen_label.modulate = Color.GREEN
+		elif omen_count < 0:
+			omen_label.modulate = Color.RED
+		else:
+			omen_label.modulate = Color.WHITE
+		omen_label.visible = omen_count != 0 and not cards_in_banish.is_empty() and is_hovering
+
+func sync_omen_count():
+	var multiplayer_node = get_tree().get_root().get_node_or_null("Main")
+	if multiplayer_node and multiplayer_node.has_method("rpc"):
+		multiplayer_node.rpc("sync_banish_omen_count", multiplayer.get_unique_id(), omen_count)
+
+func remote_set_omen_count(count: int):
+	omen_count = count
+	update_omen_label()
 
 func create_card_display(card_name: String, card_uuid: String = ""):
 	var card_display_scene = preload("res://Scenes/CardDisplay.tscn")
@@ -475,6 +531,10 @@ func remove_card_from_slot(card):
 				card.set_meta("is_marked", false)
 		if card.has_node("Area2D"):
 			card.get_node("Area2D").set_deferred("input_pickable", true)
+		if cards_in_banish.is_empty():
+			omen_count = 0
+			update_omen_label()
+			sync_omen_count()
 		reorder_z_indices()
 		update_top_card_visual()
 		if banish_view_window.visible:

--- a/Scripts/Card.gd
+++ b/Scripts/Card.gd
@@ -22,7 +22,6 @@ var was_rotated_before_drag = false
 var is_dragging = false
 var card_information_reference = null
 var runtime_modifiers = {"level": 0, "power": 0, "life": 0, "durability": 0}
-var attached_markers := {}
 var attached_counters := {}
 var is_publicly_revealed = false
 var current_direction = "North"
@@ -230,28 +229,24 @@ func _on_area_2d_input_event(_viewport: Node, event: InputEvent, _shape_idx: int
 				is_holding_left = true
 				hold_timer = 0.0
 			else:
-				if is_holding_left and hold_timer < HOLD_DURATION:
-					if can_be_marked():
-						toggle_mark()
 				_reset_hold()
 			return
 		if event.pressed:
 			if is_in_memory_slot():
-				if can_be_marked():
-					toggle_mark()
+				pass
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
 		if mouse_inside:
 			if is_in_graveyard() or is_in_banish():
-				return
-			if is_champion_card() and is_in_main_field():
-				rotate_card()
-				return
+				return		
 			var logo_nodes = get_tree().get_nodes_in_group("logo")
 			if logo_nodes.size() > 0:
 				var logo_node = logo_nodes[0]
 				if logo_node.has_method("has_active_status") and logo_node.has_active_status():
 					apply_logo_status_to_self(logo_node)
 					return
+			if is_champion_card() and is_in_main_field():
+				rotate_card()
+				return
 			popup_menu.clear()
 			if is_token():
 				if is_in_main_field():
@@ -523,8 +518,6 @@ func transform_card():
 	if is_marked:
 		set_marked(false)
 	_update_card_image(new_slug)
-	attached_markers.clear()
-	attached_counters.clear()
 	if current_field and current_field.has_method("notify_card_transformed"):
 		current_field.notify_card_transformed(self)
 	var multiplayer_node = get_tree().get_root().get_node_or_null("Main")
@@ -538,6 +531,9 @@ func transform_card():
 		if current_field.has_method("is_champion_card") and current_field.is_champion_card(self) and not is_regalia_card():
 			if current_field.current_champion_card and current_field.current_champion_card != self:
 				var prev = current_field.current_champion_card
+				if "attached_counters" in prev:
+					for c_name in prev.attached_counters:
+						attached_counters[c_name] = prev.attached_counters[c_name]
 				if "champion_lineage" in prev:
 					for entry in prev.champion_lineage:
 						add_to_lineage(entry)
@@ -662,12 +658,15 @@ func _build_plds_text(data: Dictionary) -> String:
 func _build_plds_text_effective(data: Dictionary) -> String:
 	var parts: Array[String] = []
 	var mods = runtime_modifiers if is_in_main_field() else {"level": 0, "power": 0, "life": 0, "durability": 0}
+	var buff_count = attached_counters.get("Buff", 0)
+	var debuff_count = attached_counters.get("Debuff", 0)
+	var counter_mod = buff_count - debuff_count
 	if data.has("power") and data["power"] != null:
-		var val = int(data["power"]) + int(mods.get("power", 0))
+		var val = int(data["power"]) + int(mods.get("power", 0)) + counter_mod
 		val = max(0, val)
 		parts.append("POW. %s" % str(val))
 	if data.has("life") and data["life"] != null:
-		var val2 = int(data["life"]) + int(mods.get("life", 0))
+		var val2 = int(data["life"]) + int(mods.get("life", 0)) + counter_mod
 		val2 = max(0, val2)
 		parts.append("LIFE %s" % str(val2))
 	if data.has("durability") and data["durability"] != null:
@@ -786,7 +785,6 @@ func set_current_field(field):
 	var was_in_main = is_in_main_field()
 	current_field = field
 	if _is_hand_field(current_field):
-		attached_markers.clear()
 		attached_counters.clear()
 	var now_in_main = is_in_main_field()
 	if was_in_main and not now_in_main:
@@ -871,22 +869,32 @@ func apply_logo_status_to_self(logo_node):
 		if applied_delta != 0 and current_field and current_field.has_method("is_champion_card") and current_field.is_champion_card(self):
 			if current_field.has_method("adjust_champion_life_delta"):
 				current_field.adjust_champion_life_delta(applied_delta)
-	if logo_node.custom_markers.size() > 0:
-		for marker_name in logo_node.custom_markers.keys():
-			var delta_val = int(logo_node.custom_markers[marker_name])
-			if delta_val == 0:
-				continue
-			if not attached_markers.has(marker_name):
-				attached_markers[marker_name] = 0
-			attached_markers[marker_name] = int(attached_markers[marker_name]) + delta_val
 	if logo_node.custom_counters.size() > 0:
 		for counter_name in logo_node.custom_counters.keys():
 			var delta_valc = int(logo_node.custom_counters[counter_name])
-			if delta_valc == 0:
+			if delta_valc == 0 or counter_name == "Omen":
 				continue
-			if not attached_counters.has(counter_name):
-				attached_counters[counter_name] = 0
-			attached_counters[counter_name] = int(attached_counters[counter_name]) + delta_valc
+			if delta_valc > 0:
+				if counter_name == "Buff":
+					var debuff = attached_counters.get("Debuff", 0)
+					var cancel = min(debuff, delta_valc)
+					attached_counters["Debuff"] = debuff - cancel
+					delta_valc -= cancel
+				elif counter_name == "Debuff":
+					var buff = attached_counters.get("Buff", 0)
+					var cancel = min(buff, delta_valc)
+					attached_counters["Buff"] = buff - cancel
+					delta_valc -= cancel
+				if delta_valc > 0:
+					attached_counters[counter_name] = attached_counters.get(counter_name, 0) + delta_valc
+			else:
+				attached_counters[counter_name] = attached_counters.get(counter_name, 0) + delta_valc
+			var keys_to_remove = []
+			for k in attached_counters.keys():
+				if attached_counters[k] <= 0:
+					keys_to_remove.append(k)
+			for k in keys_to_remove:
+				attached_counters.erase(k)
 	logo_node.reset_all_status_values()
 	if card_level_lable:
 		card_level_lable.clear()
@@ -896,9 +904,6 @@ func apply_logo_status_to_self(logo_node):
 	if card_information_reference and mouse_inside and not is_dragging:
 		card_information_reference.show_card_preview(self)
 	sync_stats_to_opponent()
-
-func get_attached_markers() -> Dictionary:
-	return attached_markers.duplicate()
 
 func get_attached_counters() -> Dictionary:
 	return attached_counters.duplicate()
@@ -1030,7 +1035,6 @@ func _convert_to_opponent_banish_visuals(final_pos, face_down):
 	if "original_owner_id" in new_opp_card:
 		new_opp_card.original_owner_id = original_owner_id
 	new_opp_card.runtime_modifiers = runtime_modifiers.duplicate()
-	new_opp_card.attached_markers = attached_markers.duplicate()
 	new_opp_card.attached_counters = attached_counters.duplicate()
 	new_opp_card.is_marked = is_marked
 	if new_opp_card.has_method("update_visuals_based_on_mark"):
@@ -1199,7 +1203,7 @@ func sync_stats_to_opponent(forced_rot: float = -999.0):
 	var rot_to_send = rotation_degrees if forced_rot == -999.0 else forced_rot
 	var multiplayer_node = get_tree().get_root().get_node("Main")
 	if multiplayer_node and multiplayer_node.has_method("rpc"):
-		multiplayer_node.rpc("sync_card_state", multiplayer.get_unique_id(), get_uuid(), slug, runtime_modifiers, attached_markers, attached_counters, current_direction, rot_to_send, is_marked)
+		multiplayer_node.rpc("sync_card_state", multiplayer.get_unique_id(), get_uuid(), slug, runtime_modifiers, attached_counters, current_direction, rot_to_send, is_marked)
 
 func reveal_to_opponent(skip_animation: bool = false):
 	if (not is_in_memory_slot() and not is_in_hand()) or is_publicly_revealed:
@@ -1416,7 +1420,6 @@ func give_control_to_opponent():
 			"slug": get_slug_from_card(),
 			"uuid": get_uuid() if get_uuid() else "",
 			"modifiers": runtime_modifiers,
-			"markers": attached_markers,
 			"counters": attached_counters,
 			"direction": current_direction,
 			"rot_deg": target_rot,
@@ -1447,7 +1450,6 @@ func _convert_to_opponent_card_visuals(final_pos, final_rot):
 	if "original_owner_id" in new_opp_card:
 		new_opp_card.original_owner_id = original_owner_id
 	new_opp_card.runtime_modifiers = runtime_modifiers.duplicate()
-	new_opp_card.attached_markers = attached_markers.duplicate()
 	new_opp_card.attached_counters = attached_counters.duplicate()
 	new_opp_card.is_marked = is_marked
 	if new_opp_card.has_method("update_visuals_based_on_mark"):

--- a/Scripts/CardInformation.gd
+++ b/Scripts/CardInformation.gd
@@ -8,7 +8,6 @@ extends Node2D
 @onready var card_element_lable = $Element
 @onready var card_cost_lable = $Cost
 @onready var card_PLDS_lable = $PowerLifeDurSpeed
-@onready var card_Markers_lable = $Markers
 @onready var card_Counters_lable = $Counters
 
 var card_database_reference = null
@@ -114,8 +113,6 @@ func _update_card_display(slug: String):
 	card_element_lable.clear()
 	card_cost_lable.clear()
 	card_PLDS_lable.clear()
-	if card_Markers_lable:
-		card_Markers_lable.clear()
 	if card_Counters_lable:
 		card_Counters_lable.clear()
 	if preview_sprite and slug != "":
@@ -224,32 +221,17 @@ func _update_card_display(slug: String):
 	if plds_text_to_display != "":
 		card_PLDS_lable.append_text("[left]%s[/left]" % plds_text_to_display)
 	if last_displayed_card and is_instance_valid(last_displayed_card):
-		var markers_text_lines: Array[String] = []
 		var counters_text_lines: Array[String] = []
 		var show_custom = _should_show_custom(last_displayed_card)
 		if show_custom:
-			var any_markers := false
-			var any_counters := false
-			if last_displayed_card.has_method("get_attached_markers"):
-				var mk = last_displayed_card.get_attached_markers()
-				for marker_name in mk.keys():
-					var v = int(mk[marker_name])
-					var signs = "+" if v > 0 else ""
-					markers_text_lines.append("%s %s%s" % [str(marker_name), signs, str(v)])
-				if mk.size() > 0:
-					any_markers = true
 			if last_displayed_card.has_method("get_attached_counters"):
 				var cn = last_displayed_card.get_attached_counters()
 				for counter_name in cn.keys():
 					var v2 = int(cn[counter_name])
 					var signs2 = "+" if v2 > 0 else ""
 					counters_text_lines.append("%s %s%s" % [str(counter_name), signs2, str(v2)])
-				if cn.size() > 0:
-					any_counters = true
-			if card_Markers_lable and any_markers:
-				card_Markers_lable.append_text("[left][b]Markers:[/b]\n%s[/left]" % "\n".join(markers_text_lines))
-			if card_Counters_lable and any_counters:
-				card_Counters_lable.append_text("[left][b]Counters:[/b]\n%s[/left]" % "\n".join(counters_text_lines))
+				if not counters_text_lines.is_empty() and card_Counters_lable:
+					card_Counters_lable.append_text("[left][b]Counters:[/b]\n%s[/left]" % "\n".join(counters_text_lines))
 
 func _should_show_custom(card) -> bool:
 	if not card or not is_instance_valid(card):
@@ -317,12 +299,18 @@ func _build_plds_text_effective(data: Dictionary, mods: Dictionary) -> String:
 	return " - ".join(parts)
 
 func get_effective_mods_for_card() -> Dictionary:
-	var zero = {"level": 0, "power": 0, "life": 0, "durability": 0}
+	var mods = {"level": 0, "power": 0, "life": 0, "durability": 0}
 	if last_displayed_card and is_instance_valid(last_displayed_card):
 		if last_displayed_card.has_method("is_in_main_field") and last_displayed_card.is_in_main_field():
 			if last_displayed_card.has_method("get_runtime_modifiers"):
-				return last_displayed_card.get_runtime_modifiers()
-	return zero
+				mods = last_displayed_card.get_runtime_modifiers().duplicate()
+			if last_displayed_card.has_method("get_attached_counters"):
+				var counters = last_displayed_card.get_attached_counters()
+				var buff = int(counters.get("Buff", 0))
+				var debuff = int(counters.get("Debuff", 0))
+				mods["power"] += (buff - debuff)
+				mods["life"] += (buff - debuff)
+	return mods
 
 func clear_preview():
 	if card_name_label:

--- a/Scripts/Logo.gd
+++ b/Scripts/Logo.gd
@@ -21,23 +21,16 @@ var showing_level_menu := false
 var showing_durability_menu := false
 var showing_power_menu := false
 var showing_life_menu := false
-var showing_markers_menu := false
-var showing_specific_marker_menu := false
 var showing_counters_menu := false
 var showing_specific_counter_menu := false
-var current_marker_name := ""
 var current_counter_name := ""
 var level_value := 0
 var durability_value := 0
 var power_value := 0
 var life_value := 0
-var custom_markers := {}
-var marker_labels := {}
 var custom_counters := {}
 var counter_labels := {}
 var chat_node = null
-var add_marker_dialog: AcceptDialog
-var marker_name_input: LineEdit
 var add_counter_dialog: AcceptDialog
 var counter_name_input: LineEdit
 var original_menu_pos: Vector2 = Vector2.ZERO
@@ -49,10 +42,15 @@ func _ready():
 	add_to_group("logo")
 	$Area2D.input_pickable = true
 	$Area2D.input_event.connect(_on_Area2D_input_event)
+	custom_counters["Buff"] = 0
+	custom_counters["Debuff"] = 0
+	custom_counters["Enlighten"] = 0
+	custom_counters["Omen"] = 0
 	build_main_menu()
 	setup_status_labels()
-	setup_marker_input_dialog()
 	setup_counter_input_dialog()
+	for c_name in custom_counters.keys():
+		create_counter_label(c_name)
 	update_status_display()
 	find_chat_node()
 	Logo_view_window.close_requested.connect(_on_logo_view_close)
@@ -67,22 +65,6 @@ func _ready():
 	var err = config.load("user://player_config.cfg")
 	if err == OK:
 		player_name = config.get_value("Player", "Name", "Player")
-
-func setup_marker_input_dialog():
-	add_marker_dialog = AcceptDialog.new()
-	add_marker_dialog.title = "Add New Marker"
-	add_marker_dialog.size = Vector2(300, 120)
-	var vbox = VBoxContainer.new()
-	var label = Label.new()
-	label.text = "Enter marker name:"
-	marker_name_input = LineEdit.new()
-	marker_name_input.placeholder_text = "Marker name..."
-	marker_name_input.max_length = 17
-	vbox.add_child(label)
-	vbox.add_child(marker_name_input)
-	add_marker_dialog.add_child(vbox)
-	add_child(add_marker_dialog)
-	add_marker_dialog.confirmed.connect(_on_marker_name_confirmed)
 
 func setup_counter_input_dialog():
 	add_counter_dialog = AcceptDialog.new()
@@ -100,14 +82,6 @@ func setup_counter_input_dialog():
 	add_child(add_counter_dialog)
 	add_counter_dialog.confirmed.connect(_on_counter_name_confirmed)
 
-func _on_marker_name_confirmed():
-	var marker_name = marker_name_input.text.strip_edges()
-	if marker_name != "" and not custom_markers.has(marker_name):
-		custom_markers[marker_name] = 0
-		create_marker_label(marker_name)
-	marker_name_input.text = ""
-	build_markers_menu()
-
 func _on_counter_name_confirmed():
 	var counter_name = counter_name_input.text.strip_edges()
 	if counter_name != "" and not custom_counters.has(counter_name):
@@ -115,17 +89,6 @@ func _on_counter_name_confirmed():
 		create_counter_label(counter_name)
 	counter_name_input.text = ""
 	build_counters_menu()
-
-func create_marker_label(marker_name: String):
-	var label = Label.new()
-	label.name = "MarkerLabel_" + marker_name
-	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
-	label.add_theme_font_size_override("font_size", 16)
-	label.z_index = 1000
-	label.visible = false
-	add_child(label)
-	marker_labels[marker_name] = label
 
 func create_counter_label(counter_name: String):
 	var label = Label.new()
@@ -244,18 +207,6 @@ func update_status_display():
 		offset_y += line_height
 	else:
 		life_label.visible = false
-	for marker_name in custom_markers.keys():
-		var value = custom_markers[marker_name]
-		if value != 0 and marker_labels.has(marker_name):
-			var label = marker_labels[marker_name]
-			var marker_text = marker_name + " " + ("+" if value > 0 else "") + str(value)
-			label.text = marker_text
-			label.modulate = Color.GREEN if value > 0 else Color.RED
-			label.position = mouse_pos + Vector2(15, -15 + offset_y)
-			label.visible = true
-			offset_y += line_height
-		elif marker_labels.has(marker_name):
-			marker_labels[marker_name].visible = false
 	for counter_name in custom_counters.keys():
 		var value = custom_counters[counter_name]
 		if value != 0 and counter_labels.has(counter_name):
@@ -287,8 +238,7 @@ func build_main_menu():
 	showing_durability_menu = false
 	showing_power_menu = false
 	showing_life_menu = false
-	showing_markers_menu = false
-	showing_specific_marker_menu = false
+	showing_life_menu = false
 	showing_counters_menu = false
 	showing_specific_counter_menu = false
 	clear_custom_menu()
@@ -297,7 +247,7 @@ func build_main_menu():
 	add_custom_item("Roll Dice", 102)
 	add_custom_item("RPS", 104)
 	add_custom_item("Status Modification", 105)
-	add_custom_item("Add Markers", 107)
+	add_custom_item("Counters", 107)
 	add_custom_item("Add Counters", 108)
 	add_custom_item("Summon Token", 106)
 	add_custom_item("Summon Mastery", 109)
@@ -379,7 +329,7 @@ func adjust_custom_menu_position():
 		pos.y = 0
 	logo_menu.global_position = pos
 
-func build_markers_menu():
+func build_predefined_counters_menu():
 	showing_dice_menu = false
 	showing_rps_menu = false
 	showing_status_menu = false
@@ -387,15 +337,14 @@ func build_markers_menu():
 	showing_durability_menu = false
 	showing_power_menu = false
 	showing_life_menu = false
-	showing_markers_menu = true
-	showing_specific_marker_menu = false
-	showing_counters_menu = false
+	showing_counters_menu = true
 	showing_specific_counter_menu = false
 	clear_custom_menu()
-	add_custom_item("Add", 500)
-	for marker_name in custom_markers.keys():
-		add_custom_item(marker_name + " +", 600, {"action": "increase", "marker": marker_name})
-		add_custom_item(marker_name + " -", 600, {"action": "decrease", "marker": marker_name})
+	var predefined = ["Buff", "Debuff", "Enlighten", "Omen"]
+	for c_name in predefined:
+		add_custom_item(c_name + " +", 700, {"action": "increase", "counter": c_name})
+		if c_name != "Buff" and c_name != "Debuff":
+			add_custom_item(c_name + " -", 700, {"action": "decrease", "counter": c_name})
 	add_custom_item("Back", 999, {}, true)
 	finalize_custom_menu()
 
@@ -407,15 +356,15 @@ func build_counters_menu():
 	showing_durability_menu = false
 	showing_power_menu = false
 	showing_life_menu = false
-	showing_markers_menu = false
-	showing_specific_marker_menu = false
 	showing_counters_menu = true
 	showing_specific_counter_menu = false
 	clear_custom_menu()
 	add_custom_item("Add", 501)
+	var predefined = ["Buff", "Debuff", "Enlighten", "Omen"]
 	for counter_name in custom_counters.keys():
-		add_custom_item(counter_name + " +", 700, {"action": "increase", "counter": counter_name})
-		add_custom_item(counter_name + " -", 700, {"action": "decrease", "counter": counter_name})
+		if not predefined.has(counter_name):
+			add_custom_item(counter_name + " +", 700, {"action": "increase", "counter": counter_name})
+			add_custom_item(counter_name + " -", 700, {"action": "decrease", "counter": counter_name})
 	add_custom_item("Back", 999, {}, true)
 	finalize_custom_menu()
 
@@ -427,8 +376,6 @@ func build_dice_menu():
 	showing_durability_menu = false
 	showing_power_menu = false
 	showing_life_menu = false
-	showing_markers_menu = false
-	showing_specific_marker_menu = false
 	showing_counters_menu = false
 	showing_specific_counter_menu = false
 	showing_specific_counter_menu = false
@@ -447,8 +394,6 @@ func build_rps_menu():
 	showing_durability_menu = false
 	showing_power_menu = false
 	showing_life_menu = false
-	showing_markers_menu = false
-	showing_specific_marker_menu = false
 	showing_counters_menu = false
 	showing_specific_counter_menu = false
 	showing_specific_counter_menu = false
@@ -467,8 +412,6 @@ func build_status_menu():
 	showing_durability_menu = false
 	showing_power_menu = false
 	showing_life_menu = false
-	showing_markers_menu = false
-	showing_specific_marker_menu = false
 	showing_counters_menu = false
 	showing_specific_counter_menu = false
 	showing_specific_counter_menu = false
@@ -488,8 +431,6 @@ func build_level_menu():
 	showing_durability_menu = false
 	showing_power_menu = false
 	showing_life_menu = false
-	showing_markers_menu = false
-	showing_specific_marker_menu = false
 	showing_counters_menu = false
 	showing_specific_counter_menu = false
 	showing_specific_counter_menu = false
@@ -507,8 +448,6 @@ func build_durability_menu():
 	showing_durability_menu = true
 	showing_power_menu = false
 	showing_life_menu = false
-	showing_markers_menu = false
-	showing_specific_marker_menu = false
 	showing_counters_menu = false
 	showing_specific_counter_menu = false
 	showing_specific_counter_menu = false
@@ -526,8 +465,6 @@ func build_power_menu():
 	showing_durability_menu = false
 	showing_power_menu = true
 	showing_life_menu = false
-	showing_markers_menu = false
-	showing_specific_marker_menu = false
 	showing_counters_menu = false
 	showing_specific_counter_menu = false
 	showing_specific_counter_menu = false
@@ -545,8 +482,6 @@ func build_life_menu():
 	showing_durability_menu = false
 	showing_power_menu = false
 	showing_life_menu = true
-	showing_markers_menu = false
-	showing_specific_marker_menu = false
 	showing_counters_menu = false
 	showing_specific_counter_menu = false
 	showing_specific_counter_menu = false
@@ -568,7 +503,7 @@ func _on_Area2D_input_event(_viewport, event, _shape_idx):
 		build_main_menu()
 
 func _handle_menu_action(id, metadata = {}):
-	if not showing_dice_menu and not showing_rps_menu and not showing_status_menu and not showing_level_menu and not showing_durability_menu and not showing_power_menu and not showing_life_menu and not showing_markers_menu and not showing_counters_menu:
+	if not showing_dice_menu and not showing_rps_menu and not showing_status_menu and not showing_level_menu and not showing_durability_menu and not showing_power_menu and not showing_life_menu and not showing_counters_menu:
 		if id == 100:
 			logo_menu.hide()
 			var memory_slot = find_node_recursive(get_tree().get_root(), "MEMORY")
@@ -585,7 +520,7 @@ func _handle_menu_action(id, metadata = {}):
 		elif id == 105:
 			build_status_menu()
 		elif id == 107:
-			build_markers_menu()
+			build_predefined_counters_menu()
 		elif id == 108:
 			build_counters_menu()
 		elif id == 106:
@@ -669,22 +604,6 @@ func _handle_menu_action(id, metadata = {}):
 		elif id == 408:
 			life_value -= 1
 			update_status_display()
-	elif showing_markers_menu:
-		if id == 999:
-			build_main_menu()
-		elif id == 500:
-			logo_menu.hide()
-			add_marker_dialog.popup_centered()
-		elif id >= 600:
-			var marker_name = metadata.get("marker", "")
-			var action = metadata.get("action", "")
-			if custom_markers.has(marker_name):
-				if action == "increase":
-					custom_markers[marker_name] += 1
-				elif action == "decrease":
-					custom_markers[marker_name] -= 1
-				update_status_display()
-				build_markers_menu()
 	elif showing_counters_menu:
 		if id == 999:
 			build_main_menu()
@@ -696,11 +615,19 @@ func _handle_menu_action(id, metadata = {}):
 			var action = metadata.get("action", "")
 			if custom_counters.has(counter_name):
 				if action == "increase":
-					custom_counters[counter_name] += 1
+					if counter_name == "Buff" and custom_counters["Debuff"] > 0:
+						custom_counters["Debuff"] -= 1
+					elif counter_name == "Debuff" and custom_counters["Buff"] > 0:
+						custom_counters["Buff"] -= 1
+					else:
+						custom_counters[counter_name] += 1
 				elif action == "decrease":
 					custom_counters[counter_name] -= 1
 				update_status_display()
-				build_counters_menu()
+				if ["Buff", "Debuff", "Enlighten", "Omen"].has(counter_name):
+					build_predefined_counters_menu()
+				else:
+					build_counters_menu()
 
 func fetch_slugs_by_type(target_type: String) -> Array:
 	var slugs = []
@@ -768,28 +695,18 @@ func create_card_display(card_name: String):
 
 func has_active_status() -> bool:
 	var has_basic_status = level_value != 0 or durability_value != 0 or power_value != 0 or life_value != 0
-	var has_marker_status = false
-	for value in custom_markers.values():
-		if value != 0:
-			has_marker_status = true
-			break
 	var has_counter_status = false
 	for value in custom_counters.values():
 		if value != 0:
 			has_counter_status = true
 			break
-	return has_basic_status or has_marker_status or has_counter_status
+	return has_basic_status or has_counter_status
 
 func reset_all_status_values():
 	level_value = 0
 	durability_value = 0
 	power_value = 0
 	life_value = 0
-	for key in custom_markers.keys():
-		custom_markers[key] = 0
-	for label in marker_labels.values():
-		if is_instance_valid(label):
-			label.visible = false
 	for key in custom_counters.keys():
 		custom_counters[key] = 0
 	for label in counter_labels.values():

--- a/Scripts/Main_Field.gd
+++ b/Scripts/Main_Field.gd
@@ -32,7 +32,13 @@ func add_card_to_field(card, position = null):
 					for entry in old_lineage:
 						if card.has_method("add_to_lineage"):
 							card.add_to_lineage(entry)
+				if "attached_counters" in inherit_source:
+					for c_name in inherit_source.attached_counters:
+						card.attached_counters[c_name] = inherit_source.attached_counters[c_name]
 			if current_champion_card != null and current_champion_card != card:
+				if "attached_counters" in current_champion_card and card.has_method("get") and "attached_counters" in card:
+					for c_name in current_champion_card.attached_counters:
+						card.attached_counters[c_name] = current_champion_card.attached_counters[c_name]
 				if card.has_method("add_to_lineage"):
 					var lineage_data = {
 						"slug": get_card_slug(current_champion_card),

--- a/Scripts/Multiplayer.gd
+++ b/Scripts/Multiplayer.gd
@@ -411,6 +411,17 @@ func sync_banish_flip(player_id: int, uuid: String, is_face_down: bool):
 				opp_banish.update_deck_view()
 
 @rpc("any_peer", "reliable")
+func sync_banish_omen_count(player_id: int, count: int):
+	var is_from_remote = multiplayer.get_remote_sender_id() == player_id
+	if not is_from_remote:
+		return
+	var opp_field = get_node_or_null("OpponentField")
+	if opp_field:
+		var opp_banish = opp_field.get_node_or_null("OpponentBanish")
+		if opp_banish and opp_banish.has_method("remote_set_omen_count"):
+			opp_banish.remote_set_omen_count(count)
+
+@rpc("any_peer", "reliable")
 func sync_move_to_main_field(player_id: int, uuid: String, slug: String, pos: Vector2, rot_deg: float, from_deck: bool = false, from_mat_deck: bool = false):
 	var is_from_remote = multiplayer.get_remote_sender_id() == player_id
 	if not is_from_remote:
@@ -670,7 +681,7 @@ func sync_move_to_deck(player_id: int, uuid: String, _is_top: bool):
 			card.queue_free()
 
 @rpc("any_peer", "reliable")
-func sync_card_state(player_id: int, uuid: String, slug: String, modifiers: Dictionary, markers: Dictionary, counters: Dictionary, direction: String, rot_deg: float, is_marked: bool = false):
+func sync_card_state(player_id: int, uuid: String, slug: String, modifiers: Dictionary, counters: Dictionary, direction: String, rot_deg: float, is_marked: bool = false):
 	var is_from_remote = multiplayer.get_remote_sender_id() == player_id
 	if not is_from_remote:
 		return
@@ -687,8 +698,6 @@ func sync_card_state(player_id: int, uuid: String, slug: String, modifiers: Dict
 					card.update_visuals_based_on_mark()
 			if "runtime_modifiers" in card:
 				card.runtime_modifiers = modifiers
-			if "attached_markers" in card:
-				card.attached_markers = markers
 			if "attached_counters" in card:
 				card.attached_counters = counters
 			if "current_direction" in card:
@@ -1075,7 +1084,6 @@ func _convert_opponent_to_player_card(opp_card: Node, stats: Dictionary, final_p
 	if "original_owner_id" in new_card:
 		new_card.original_owner_id = stats.get("original_owner_id", 0)
 	new_card.runtime_modifiers = stats.get("modifiers", {}).duplicate()
-	new_card.attached_markers = stats.get("markers", {}).duplicate()
 	new_card.attached_counters = stats.get("counters", {}).duplicate()
 	new_card.is_rotated = false
 	if abs(fmod(final_rot, 360.0)) > 45 and abs(fmod(final_rot, 360.0)) < 135:

--- a/Scripts/Opponent90DegreesCardSlot.gd
+++ b/Scripts/Opponent90DegreesCardSlot.gd
@@ -8,6 +8,9 @@ var marked_uuids : Array = []
 var hold_timer = 0.0
 var is_holding_left = false
 var progress_bar: TextureProgressBar
+var omen_count = 0
+var omen_label: Label
+var is_hovering = false
 
 @onready var banish_view_window = $BanishViewWindow
 @onready var grid_container = $BanishViewWindow/ScrollContainer/GridContainer
@@ -18,10 +21,15 @@ const HOLD_DURATION = 0.8
 func _ready() -> void:
 	add_to_group("rotated_slots")
 	setup_deck_view()
-	if area2d and not area2d.input_event.is_connected(_on_area_2d_input_event):
-		area2d.input_event.connect(_on_area_2d_input_event)
-	if area2d and not area2d.mouse_exited.is_connected(_on_mouse_exited):
-		area2d.mouse_exited.connect(_on_mouse_exited)
+	if area2d:
+		area2d.input_pickable = true
+		if not area2d.input_event.is_connected(_on_area_2d_input_event):
+			area2d.input_event.connect(_on_area_2d_input_event)
+		if not area2d.mouse_exited.is_connected(_on_mouse_exited):
+			area2d.mouse_exited.connect(_on_mouse_exited)
+		if not area2d.mouse_entered.is_connected(_on_mouse_entered):
+			area2d.mouse_entered.connect(_on_mouse_entered)
+	_setup_omen_label()
 	_setup_progress_bar()
 
 func _setup_progress_bar():
@@ -106,9 +114,59 @@ func _on_area_2d_input_event(_viewport, event, _shape_idx):
 				hold_timer = 0.0
 			else:
 				_reset_hold()
+		elif event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+			if cards_in_banish.is_empty():
+				return
+			var logo_nodes = get_tree().get_nodes_in_group("logo")
+			if logo_nodes.size() > 0:
+				var logo = logo_nodes[0]
+				if logo.has_method("has_active_status") and logo.has_active_status():
+					if logo.custom_counters.get("Omen", 0) != 0:
+						omen_count += logo.custom_counters["Omen"]
+						update_omen_label()
+						sync_omen_count()
+						logo.reset_all_status_values()
+						return
+
+func _on_mouse_entered():
+	is_hovering = true
+	update_omen_label()
 
 func _on_mouse_exited():
+	is_hovering = false
+	update_omen_label()
 	_reset_hold()
+
+func _setup_omen_label():
+	omen_label = get_node_or_null("OmenLabel")
+	if not omen_label:
+		omen_label = Label.new()
+		omen_label.name = "OmenLabel"
+		omen_label.add_theme_font_size_override("font_size", 20)
+		omen_label.z_index = 1500
+		omen_label.visible = false
+		add_child(omen_label)
+		omen_label.position = Vector2(575, 480)
+
+func update_omen_label():
+	if omen_label:
+		omen_label.text = "Omens : " + str(omen_count)
+		if omen_count > 0:
+			omen_label.modulate = Color.GREEN
+		elif omen_count < 0:
+			omen_label.modulate = Color.RED
+		else:
+			omen_label.modulate = Color.WHITE
+		omen_label.visible = omen_count != 0 and not cards_in_banish.is_empty() and is_hovering
+
+func sync_omen_count():
+	var multiplayer_node = get_tree().get_root().get_node_or_null("Main")
+	if multiplayer_node and multiplayer_node.has_method("rpc"):
+		multiplayer_node.rpc("sync_banish_omen_count", multiplayer.get_unique_id(), omen_count)
+
+func remote_set_omen_count(count: int):
+	omen_count = count
+	update_omen_label()
 
 func create_card_display(card_name: String, card_uuid: String = ""):
 	var card_display_scene = preload("res://Scenes/CardDisplay.tscn")

--- a/Scripts/OpponentCard.gd
+++ b/Scripts/OpponentCard.gd
@@ -8,7 +8,6 @@ var hand_position
 var mouse_inside = false
 var card_information_reference = null
 var runtime_modifiers = {"level": 0, "power": 0, "life": 0, "durability": 0}
-var attached_markers := {}
 var attached_counters := {}
 var uuid = ""
 var current_field = null
@@ -95,9 +94,6 @@ func is_in_main_field() -> bool:
 
 func get_runtime_modifiers() -> Dictionary:
 	return runtime_modifiers.duplicate()
-
-func get_attached_markers() -> Dictionary:
-	return attached_markers.duplicate()
 
 func get_attached_counters() -> Dictionary:
 	return attached_counters.duplicate()
@@ -246,8 +242,6 @@ func remote_transform(new_slug: String):
 	if anim_player and anim_player.has_animation("card_flip"):
 		anim_player.play("card_flip")
 	runtime_modifiers = {"level": 0, "power": 0, "life": 0, "durability": 0}
-	attached_markers.clear()
-	attached_counters.clear()
 	if current_field and current_field.has_method("notify_card_transformed"):
 		current_field.notify_card_transformed(self)
 	emit_signal("visuals_changed")

--- a/Scripts/OpponentHand.gd
+++ b/Scripts/OpponentHand.gd
@@ -417,9 +417,6 @@ func swap_card_data(card1, card2):
 	var temp_mods = card1.runtime_modifiers
 	card1.runtime_modifiers = card2.runtime_modifiers
 	card2.runtime_modifiers = temp_mods
-	var temp_markers = card1.attached_markers
-	card1.attached_markers = card2.attached_markers
-	card2.attached_markers = temp_markers
 	var temp_counters = card1.attached_counters
 	card1.attached_counters = card2.attached_counters
 	card2.attached_counters = temp_counters

--- a/Scripts/OpponentMainField.gd
+++ b/Scripts/OpponentMainField.gd
@@ -80,6 +80,9 @@ func notify_card_transformed(card: Node):
 			var old_uuid = ""
 			if "uuid" in current_champion_card:
 				old_uuid = current_champion_card.uuid
+			if "attached_counters" in current_champion_card:
+				for c_name in current_champion_card.attached_counters:
+					card.attached_counters[c_name] = current_champion_card.attached_counters[c_name]
 			if card.has_method("add_to_lineage"):
 				card.add_to_lineage({"slug": old_slug, "uuid": old_uuid})
 			remove_previous_champions()
@@ -119,6 +122,9 @@ func add_card_to_field(card: Node, target_pos: Vector2, target_rot_deg: float = 
 			var old_uuid = ""
 			if "uuid" in current_champion_card:
 				old_uuid = current_champion_card.uuid
+			if "attached_counters" in current_champion_card:
+				for c_name in current_champion_card.attached_counters:
+					card.attached_counters[c_name] = current_champion_card.attached_counters[c_name]
 			if card.has_method("add_to_lineage"):
 				card.add_to_lineage({"slug": old_slug, "uuid": old_uuid})
 			remove_previous_champions()


### PR DESCRIPTION
Introduce a counters system (predefined: Buff, Debuff, Enlighten, Omen) and remove the old custom markers flow. Key changes:

- Banish slots (player and opponent) now track an omen_count, show an OmenLabel on hover, support right-click to collect Omen from the Logo, and sync via a new RPC (sync_banish_omen_count). Scene files updated to add/remove relevant UI nodes.
- Logo simplified: custom markers UI and management removed; custom_counters is initialized with predefined counters and counter labels are created. Menu and dialog code adjusted to manage predefined counters and removed marker dialogs/labels/menu items.
- Card logic updated to drop attached_markers across code paths. attached_counters now interact: Buff cancels Debuff (and vice versa) on application, and counters with non-positive values are pruned. Counters contribute to effective stats (power/life) for display and previews.
- Card transformation and field/champion inheritance now transfer attached_counters between cards where appropriate.
- Multiplayer API updated: sync_card_state and related conversion flows no longer transmit markers; new RPC added for syncing banish omen counts. Receiver-side logic updated to apply counters only.
- CardInformation UI now shows only counters (Markers display removed) and computes effective modifiers including Buff/Debuff effects.

Overall removes marker-related functionality and replaces it with a unified, predefined counters system and omen UI/sync behavior.