### PR TITLE
Add opponents info UI and fix card/menu logic

### DIFF
--- a/Scenes/Opponent_Field.tscn
+++ b/Scenes/Opponent_Field.tscn
@@ -11,6 +11,7 @@
 [ext_resource type="PackedScene" uid="uid://dulc360ofen1q" path="res://Scenes/Opponent_Memory.tscn" id="9_4t60u"]
 [ext_resource type="PackedScene" uid="uid://c8w8ptylfbntf" path="res://Scenes/Opponent_Logo.tscn" id="10_4t60u"]
 [ext_resource type="Texture2D" uid="uid://4ya7n805x51x" path="res://Assets/Textures/Player Info/Over_Yellow_Mirrored.png" id="12_j2155"]
+[ext_resource type="Script" uid="uid://bwf674fkbyuad" path="res://Scripts/OpponentsInfo.gd" id="12_xqfjh"]
 [ext_resource type="Texture2D" uid="uid://blxkfgnsip0ov" path="res://Assets/Textures/Player Info/Progress_Yellow_Mirrored.png" id="13_urkt4"]
 [ext_resource type="Texture2D" uid="uid://bsfe2cbkcwbrn" path="res://Assets/Textures/Player Info/Player_photos/Player_Image.png" id="13_xqfjh"]
 [ext_resource type="Script" uid="uid://dk06c13rk3fwj" path="res://Scripts/OpponentFieldElements.gd" id="14_4t60u"]
@@ -64,6 +65,7 @@ anchors_preset = 0
 offset_top = 100.0
 offset_right = 430.0
 offset_bottom = 200.0
+script = ExtResource("12_xqfjh")
 
 [node name="TextureProgressBar" type="TextureProgressBar" parent="Opponents_Info" unique_id=1874446367]
 layout_mode = 0

--- a/Scripts/Card.gd
+++ b/Scripts/Card.gd
@@ -891,7 +891,7 @@ func apply_logo_status_to_self(logo_node):
 				attached_counters[counter_name] = attached_counters.get(counter_name, 0) + delta_valc
 			var keys_to_remove = []
 			for k in attached_counters.keys():
-				if attached_counters[k] <= 0:
+				if attached_counters[k] == 0:
 					keys_to_remove.append(k)
 			for k in keys_to_remove:
 				attached_counters.erase(k)
@@ -920,6 +920,7 @@ func apply_champion_life_delta(delta):
 			card_level_lable.clear()
 		if card_PLDS_lable:
 			card_PLDS_lable.clear()
+		sync_stats_to_opponent()
 
 func can_be_marked() -> bool:
 	var parent = current_field if current_field else get_parent()

--- a/Scripts/Logo.gd
+++ b/Scripts/Logo.gd
@@ -248,7 +248,6 @@ func build_main_menu():
 	add_custom_item("RPS", 104)
 	add_custom_item("Status Modification", 105)
 	add_custom_item("Counters", 107)
-	add_custom_item("Add Counters", 108)
 	add_custom_item("Summon Token", 106)
 	add_custom_item("Summon Mastery", 109)
 	add_custom_item("Surrender", 103, {}, true)
@@ -329,25 +328,6 @@ func adjust_custom_menu_position():
 		pos.y = 0
 	logo_menu.global_position = pos
 
-func build_predefined_counters_menu():
-	showing_dice_menu = false
-	showing_rps_menu = false
-	showing_status_menu = false
-	showing_level_menu = false
-	showing_durability_menu = false
-	showing_power_menu = false
-	showing_life_menu = false
-	showing_counters_menu = true
-	showing_specific_counter_menu = false
-	clear_custom_menu()
-	var predefined = ["Buff", "Debuff", "Enlighten", "Omen"]
-	for c_name in predefined:
-		add_custom_item(c_name + " +", 700, {"action": "increase", "counter": c_name})
-		if c_name != "Buff" and c_name != "Debuff":
-			add_custom_item(c_name + " -", 700, {"action": "decrease", "counter": c_name})
-	add_custom_item("Back", 999, {}, true)
-	finalize_custom_menu()
-
 func build_counters_menu():
 	showing_dice_menu = false
 	showing_rps_menu = false
@@ -360,10 +340,9 @@ func build_counters_menu():
 	showing_specific_counter_menu = false
 	clear_custom_menu()
 	add_custom_item("Add", 501)
-	var predefined = ["Buff", "Debuff", "Enlighten", "Omen"]
 	for counter_name in custom_counters.keys():
-		if not predefined.has(counter_name):
-			add_custom_item(counter_name + " +", 700, {"action": "increase", "counter": counter_name})
+		add_custom_item(counter_name + " +", 700, {"action": "increase", "counter": counter_name})
+		if counter_name != "Buff" and counter_name != "Debuff" and counter_name != "Enlighten" and counter_name != "Omen":
 			add_custom_item(counter_name + " -", 700, {"action": "decrease", "counter": counter_name})
 	add_custom_item("Back", 999, {}, true)
 	finalize_custom_menu()
@@ -520,8 +499,6 @@ func _handle_menu_action(id, metadata = {}):
 		elif id == 105:
 			build_status_menu()
 		elif id == 107:
-			build_predefined_counters_menu()
-		elif id == 108:
 			build_counters_menu()
 		elif id == 106:
 			logo_menu.hide()
@@ -624,10 +601,7 @@ func _handle_menu_action(id, metadata = {}):
 				elif action == "decrease":
 					custom_counters[counter_name] -= 1
 				update_status_display()
-				if ["Buff", "Debuff", "Enlighten", "Omen"].has(counter_name):
-					build_predefined_counters_menu()
-				else:
-					build_counters_menu()
+				build_counters_menu()
 
 func fetch_slugs_by_type(target_type: String) -> Array:
 	var slugs = []

--- a/Scripts/OpponentMainField.gd
+++ b/Scripts/OpponentMainField.gd
@@ -89,6 +89,8 @@ func notify_card_transformed(card: Node):
 			if "attached_counters" in current_champion_card:
 				for c_name in current_champion_card.attached_counters:
 					card.attached_counters[c_name] = current_champion_card.attached_counters[c_name]
+			if "runtime_modifiers" in current_champion_card:
+				card.runtime_modifiers = current_champion_card.runtime_modifiers.duplicate()
 			if card.has_method("add_to_lineage"):
 				card.add_to_lineage({"slug": old_slug, "uuid": old_uuid})
 			remove_previous_champions()
@@ -132,6 +134,8 @@ func add_card_to_field(card: Node, target_pos: Vector2, target_rot_deg: float = 
 			if "attached_counters" in current_champion_card:
 				for c_name in current_champion_card.attached_counters:
 					card.attached_counters[c_name] = current_champion_card.attached_counters[c_name]
+			if "runtime_modifiers" in current_champion_card:
+				card.runtime_modifiers = current_champion_card.runtime_modifiers.duplicate()
 			if card.has_method("add_to_lineage"):
 				card.add_to_lineage({"slug": old_slug, "uuid": old_uuid})
 			remove_previous_champions()

--- a/Scripts/OpponentsInfo.gd
+++ b/Scripts/OpponentsInfo.gd
@@ -1,10 +1,9 @@
 extends Control
 
 @onready var texture_progress_bar = $TextureProgressBar
-@onready var polygon_node = $Polygon2D
 
 var card_info_node = null
-var main_field_node = null
+var opponent_main_field_node = null
 var last_champion_instance = null
 var cached_base_life = 0
 
@@ -15,7 +14,7 @@ func _find_nodes():
 	var root = get_tree().current_scene
 	if root:
 		card_info_node = find_node_by_script(root, "res://Scripts/CardInformation.gd")
-		main_field_node = root.find_child("MAINFIELD", true, false)
+		opponent_main_field_node = root.find_child("OpponentMainField", true, false)
 
 func find_node_by_script(node: Node, script_path: String) -> Node:
 	if node.get_script() and node.get_script().resource_path == script_path:
@@ -29,12 +28,12 @@ func find_node_by_script(node: Node, script_path: String) -> Node:
 func _process(_delta):
 	if not texture_progress_bar:
 		return
-	if not main_field_node or not is_instance_valid(main_field_node):
+	if not opponent_main_field_node or not is_instance_valid(opponent_main_field_node):
 		_find_nodes()
-		if not main_field_node:
+		if not opponent_main_field_node:
 			texture_progress_bar.value = 100
 			return
-	var champion = main_field_node.get("current_champion_card")
+	var champion = opponent_main_field_node.get("current_champion_card")
 	if not champion or not is_instance_valid(champion):
 		texture_progress_bar.value = 100
 		last_champion_instance = null

--- a/Scripts/OpponentsInfo.gd.uid
+++ b/Scripts/OpponentsInfo.gd.uid
@@ -1,0 +1,1 @@
+uid://bwf674fkbyuad


### PR DESCRIPTION
Add OpponentsInfo.gd and hook it into Opponent_Field.tscn to drive the opponent TextureProgressBar (calculates base/current life from card DB, runtime_modifiers and Buff/Debuff counters). Mirror the same progress-bar logic in PlayerInfo.gd. Ensure runtime_modifiers are duplicated when copying/transferring champion data in OpponentMainField.gd. In Card.gd, only remove attached counters when equal to 0 (was <= 0) and call sync_stats_to_opponent() after apply_champion_life_delta. Simplify Logo.gd menus: remove the predefined-counters submenu and the "Add Counters" menu item, and streamline counters menu generation and update flow. Add the UID file for the new script and update the scene to reference the script.