### PR TITLE
Add element activation/deactivation and prismatic

### DIFF
--- a/Scripts/CardManager.gd
+++ b/Scripts/CardManager.gd
@@ -555,7 +555,7 @@ func free_card_from_slot(card):
 						if slot.has_property("card_in_slot"):
 							slot.card_in_slot = false
 						break
-	var all_nodes = get_tree().get_nodes_in_group("")
+	var all_nodes = get_tree().get_nodes_in_group("main_fields")
 	for node in all_nodes:
 		if node.name == "MAINFIELD" and is_instance_valid(node) and node.has_method("remove_card_from_field"):
 			if card in node.cards_in_field:
@@ -921,7 +921,7 @@ func cleanup():
 func remove_card_from_main_field(card):
 	if not card or not is_instance_valid(card):
 		return
-	var all_nodes = get_tree().get_nodes_in_group("")
+	var all_nodes = get_tree().get_nodes_in_group("main_fields")
 	for node in all_nodes:
 		if node.name == "MAINFIELD" and is_instance_valid(node) and node.has_method("remove_card_from_field"):
 			if card in node.cards_in_field:

--- a/Scripts/Element.gd
+++ b/Scripts/Element.gd
@@ -1,12 +1,14 @@
 extends Node2D
 
 @onready var sprite = $Sprite2D
+var activation_count: int = 0
 
 func _ready():
 	sprite.modulate.a = 0.0
 
 func activate():
-	if sprite.modulate.a > 0.9:
+	activation_count += 1
+	if activation_count > 1:
 		return
 	sprite.modulate.a = 1.0
 	if get_parent() and get_parent().has_method("refresh_layout"):
@@ -16,3 +18,18 @@ func activate():
 	var multiplayer_node = get_tree().current_scene
 	if multiplayer_node and multiplayer_node.has_method("rpc"):
 		multiplayer_node.rpc("sync_element", name, 1.0)
+
+func deactivate():
+	activation_count -= 1
+	if activation_count > 0:
+		return
+	if activation_count < 0:
+		activation_count = 0
+	sprite.modulate.a = 0.0
+	if get_parent() and get_parent().has_method("refresh_layout"):
+		get_parent().refresh_layout()
+	if name.begins_with("Opponent"):
+		return
+	var multiplayer_node = get_tree().current_scene
+	if multiplayer_node and multiplayer_node.has_method("rpc"):
+		multiplayer_node.rpc("sync_element", name, 0.0)

--- a/Scripts/Main_Field.gd
+++ b/Scripts/Main_Field.gd
@@ -19,34 +19,55 @@ func activate_champion_elements(card):
 	if not card or not is_instance_valid(card):
 		return
 	var root = get_tree().current_scene
-	var card_info_ref = find_card_information_reference()
-	if not card_info_ref or not card_info_ref.card_database_reference:
-		if root and root.has_method("find_child"):
-			card_info_ref = root.find_child("CardInformation", true, false)
-	if not card_info_ref or not card_info_ref.card_database_reference:
-		return
 	var card_slug = get_card_slug(card)
 	if card_slug == "":
-		return
-	var element_name = ""
-	if card_info_ref.has_method("get_card_element"):
-		element_name = card_info_ref.get_card_element(card_slug)
-	if element_name == "":
 		return
 	var elements_node = get_parent().get_node_or_null("Elements")
 	if not elements_node:
 		if root and root.has_method("find_child"):
 			elements_node = root.find_child("Elements", true, false)	
+	if not elements_node:
+		return
+	if card_slug.contains("prismatic-sanctuary"):
+		for e_name in ["Fire", "Water", "Wind"]:
+			var e_node = elements_node.get_node_or_null(e_name)
+			if e_node and e_node.has_method("activate"):
+				e_node.activate()
+	if is_champion_card(card):
+		var card_info_ref = find_card_information_reference()
+		if not card_info_ref or not card_info_ref.card_database_reference:
+			if root and root.has_method("find_child"):
+				card_info_ref = root.find_child("CardInformation", true, false)
+		var element_name = ""
+		if card_info_ref and card_info_ref.has_method("get_card_element"):
+			element_name = card_info_ref.get_card_element(card_slug)
+		if element_name != "":
+			if not first_champion_summoned:
+				var norm = elements_node.get_node_or_null("Norm")
+				if norm and norm.has_method("activate"):
+					norm.activate()
+				first_champion_summoned = true
+			var capitalized_name = str(element_name).capitalize()
+			var element_node = elements_node.get_node_or_null(capitalized_name)
+			if element_node and element_node.has_method("activate"):
+				element_node.activate()
+
+func deactivate_card_elements(card):
+	if not card or not is_instance_valid(card):
+		return
+	var card_slug = get_card_slug(card)
+	if not card_slug.contains("prismatic-sanctuary"):
+		return
+	var root = get_tree().current_scene
+	var elements_node = get_parent().get_node_or_null("Elements")
+	if not elements_node:
+		if root and root.has_method("find_child"):
+			elements_node = root.find_child("Elements", true, false)	
 	if elements_node:
-		if not first_champion_summoned:
-			var norm = elements_node.get_node_or_null("Norm")
-			if norm and norm.has_method("activate"):
-				norm.activate()
-			first_champion_summoned = true
-		var capitalized_name = str(element_name).capitalize()
-		var element_node = elements_node.get_node_or_null(capitalized_name)
-		if element_node and element_node.has_method("activate"):
-			element_node.activate()
+		for e_name in ["Fire", "Water", "Wind"]:
+			var e_node = elements_node.get_node_or_null(e_name)
+			if e_node and e_node.has_method("deactivate"):
+				e_node.deactivate()
 
 @warning_ignore("shadowed_variable_base_class")
 func add_card_to_field(card, position = null):
@@ -76,14 +97,13 @@ func add_card_to_field(card, position = null):
 				if card.has_method("add_to_lineage"):
 					var lineage_data = {
 						"slug": get_card_slug(current_champion_card),
-						"uuid": current_champion_card.uuid if "uuid" in current_champion_card else ""
-					}
+						"uuid": current_champion_card.uuid if "uuid" in current_champion_card else ""}
 					card.add_to_lineage(lineage_data)
 				remove_previous_champions()
 			current_champion_card = card
 			cards_in_field.append(card)
 			card_in_slot = true
-		activate_champion_elements(card)
+			activate_champion_elements(card)
 		if card and is_instance_valid(card) and card.has_method("apply_champion_life_delta"):
 			card.apply_champion_life_delta(champion_life_delta)
 		card.global_position = global_position + Vector2(0, -20)
@@ -113,6 +133,8 @@ func add_card_to_field(card, position = null):
 			current_mastery_card = card
 			cards_in_field.append(card)
 			card_in_slot = true
+			if get_card_slug(card).contains("prismatic-sanctuary"):
+				activate_champion_elements(card)
 		if position != null:
 			card.global_position = position
 		else:
@@ -131,6 +153,8 @@ func add_card_to_field(card, position = null):
 		if not (card in cards_in_field):
 			cards_in_field.append(card)
 			card_in_slot = true
+			if get_card_slug(card).contains("prismatic-sanctuary"):
+				activate_champion_elements(card)
 		if card.has_method("set_current_field"):
 			card.set_current_field(self)
 		if position != null:
@@ -157,6 +181,7 @@ func remove_previous_champions():
 		if current_champion_card.get_parent():
 			current_champion_card.get_parent().remove_child(current_champion_card)
 		current_champion_card.queue_free()
+		deactivate_card_elements(current_champion_card)
 		current_champion_card = null
 		
 func is_champion_card(card) -> bool:
@@ -189,6 +214,7 @@ func remove_previous_mastery():
 		if current_mastery_card.get_parent():
 			current_mastery_card.get_parent().remove_child(current_mastery_card)
 		current_mastery_card.queue_free()
+		deactivate_card_elements(current_mastery_card)
 		current_mastery_card = null
 
 func is_mastery_card(card) -> bool:
@@ -229,6 +255,7 @@ func remove_card_from_field(card):
 			current_champion_card = null
 		if card == current_mastery_card:
 			current_mastery_card = null
+		deactivate_card_elements(card)
 
 func bring_card_to_front(card):
 	if not card or not is_instance_valid(card):

--- a/Scripts/OpponentMainField.gd
+++ b/Scripts/OpponentMainField.gd
@@ -45,31 +45,62 @@ func activate_champion_elements(card):
 		card_info = find_node_by_script(root, "res://Scripts/CardInformation.gd")
 	if not card_info:
 		return
-	var element_name = ""
-	if card_info.has_method("get_card_element"):
-		element_name = card_info.get_card_element(card_slug)
-	if element_name == "":
+	var elements_node = get_parent().get_node_or_null("OpponentElements")
+	if not elements_node:
+		if root:
+			elements_node = root.find_child("OpponentElements", true, false)	
+	if not elements_node:
 		return
+	if card_slug.contains("prismatic-sanctuary"):
+		for e_name in ["Fire", "Water", "Wind"]:
+			var e_node = elements_node.get_node_or_null("Opponent" + e_name)
+			if e_node and e_node.has_method("activate"):
+				e_node.activate()
+			elif e_node:
+				var sprite = e_node.get_node_or_null("Sprite2D")
+				if sprite: sprite.modulate.a = 1.0
+	if is_champion_card(card):
+		var element_name = ""
+		if card_info.has_method("get_card_element"):
+			element_name = card_info.get_card_element(card_slug)
+		if element_name != "":
+			if not first_champion_summoned:
+				var norm = elements_node.get_node_or_null("OpponentNorm")
+				if norm and norm.has_method("activate"):
+					norm.activate()
+				elif norm:
+					var sprite = norm.get_node_or_null("Sprite2D")
+					if sprite: sprite.modulate.a = 1.0
+				first_champion_summoned = true
+			var capitalized_name = str(element_name).capitalize()
+			var element_node = elements_node.get_node_or_null("Opponent" + capitalized_name)
+			if element_node and element_node.has_method("activate"):
+				element_node.activate()
+			elif element_node:
+				var sprite = element_node.get_node_or_null("Sprite2D")
+				if sprite: sprite.modulate.a = 1.0
+
+func deactivate_card_elements(card):
+	if not card or not is_instance_valid(card):
+		return
+	var card_slug = ""
+	if card.has_meta("slug"):
+		card_slug = card.get_meta("slug")
+	if not card_slug.contains("prismatic-sanctuary"):
+		return
+	var root = get_tree().current_scene
 	var elements_node = get_parent().get_node_or_null("OpponentElements")
 	if not elements_node:
 		if root:
 			elements_node = root.find_child("OpponentElements", true, false)	
 	if elements_node:
-		if not first_champion_summoned:
-			var norm = elements_node.get_node_or_null("OpponentNorm")
-			if norm and norm.has_method("activate"):
-				norm.activate()
-			elif norm:
-				var sprite = norm.get_node_or_null("Sprite2D")
-				if sprite: sprite.modulate.a = 1.0
-			first_champion_summoned = true
-		var capitalized_name = str(element_name).capitalize()
-		var element_node = elements_node.get_node_or_null("Opponent" + capitalized_name)
-		if element_node and element_node.has_method("activate"):
-			element_node.activate()
-		elif element_node:
-			var sprite = element_node.get_node_or_null("Sprite2D")
-			if sprite: sprite.modulate.a = 1.0
+		for e_name in ["Fire", "Water", "Wind"]:
+			var e_node = elements_node.get_node_or_null("Opponent" + e_name)
+			if e_node and e_node.has_method("deactivate"):
+				e_node.deactivate()
+			elif e_node:
+				var sprite = e_node.get_node_or_null("Sprite2D")
+				if sprite: sprite.modulate.a = 0.0
 
 func notify_card_transformed(card: Node):
 	if is_champion_card(card):
@@ -95,7 +126,8 @@ func notify_card_transformed(card: Node):
 				card.add_to_lineage({"slug": old_slug, "uuid": old_uuid})
 			remove_previous_champions()
 		current_champion_card = card
-		activate_champion_elements(card)
+		if not (card in cards_in_field):
+			activate_champion_elements(card)
 		card.global_position = global_position + Vector2(0, 20)
 		card.z_index = 400
 	elif card == current_champion_card:
@@ -108,6 +140,7 @@ func remove_previous_champions():
 		if current_champion_card.get_parent():
 			current_champion_card.get_parent().remove_child(current_champion_card)
 		current_champion_card.queue_free()
+		deactivate_card_elements(current_champion_card)
 		current_champion_card = null
 
 func _ready() -> void:
@@ -140,16 +173,22 @@ func add_card_to_field(card: Node, target_pos: Vector2, target_rot_deg: float = 
 				card.add_to_lineage({"slug": old_slug, "uuid": old_uuid})
 			remove_previous_champions()
 		current_champion_card = card
-		activate_champion_elements(card)
+		if not (card in cards_in_field):
+			activate_champion_elements(card)
 		card.global_position = global_position + Vector2(0, 20)
 	elif is_mastery_card(card):
 		if current_mastery_card != null and current_mastery_card != card:
 			remove_previous_mastery()
 		current_mastery_card = card
+		if not (card in cards_in_field):
+			if get_card_slug(card).contains("prismatic-sanctuary"):
+				activate_champion_elements(card)
 	if card.has_method("set_current_field"):
 		card.set_current_field(self)
 	if card not in cards_in_field:
 		cards_in_field.append(card)
+		if get_card_slug(card).contains("prismatic-sanctuary") and not is_champion_card(card) and not is_mastery_card(card):
+			activate_champion_elements(card)
 	var card_image = card.get_node_or_null("CardImage")
 	var card_image_back = card.get_node_or_null("CardImageBack")
 	if card_image and card_image_back:
@@ -166,6 +205,7 @@ func remove_previous_mastery():
 	if current_mastery_card and is_instance_valid(current_mastery_card):
 		cards_in_field.erase(current_mastery_card)
 		current_mastery_card.queue_free()
+		deactivate_card_elements(current_mastery_card)
 		current_mastery_card = null
 
 func is_mastery_card(card) -> bool:
@@ -192,6 +232,7 @@ func remove_card_from_field(card: Node) -> void:
 			current_champion_card = null
 		if card == current_mastery_card:
 			current_mastery_card = null
+		deactivate_card_elements(card)
 
 func bring_card_to_front(card: Node) -> void:
 	var idx := cards_in_field.find(card)
@@ -215,3 +256,8 @@ func connect_card_signals(card):
 	var card_manager = get_tree().get_root().find_child("CardManager", true, false)
 	if card_manager and card_manager.has_method("connect_card_signals"):
 		card_manager.connect_card_signals(card)
+
+func get_card_slug(card) -> String:
+	if card.has_meta("slug"):
+		return card.get_meta("slug")
+	return ""


### PR DESCRIPTION
Fix group lookup in CardManager and extend element handling across main and opponent fields. Element.gd: add activation_count and a new deactivate() to prevent double-activation, support nested activations, and sync state via RPC. Main_Field.gd: refactor activate_champion_elements to locate an Elements node, add support for prismatic-sanctuary (activates Fire/Water/Wind), only activate champion element when appropriate, add deactivate_card_elements, and call activation/deactivation at card add/remove points to keep element state consistent. OpponentMainField.gd: mirror main field changes using OpponentElements and Opponent-prefixed nodes, add sprite fallback when nodes lack methods, add deactivate_card_elements and get_card_slug helper, and avoid duplicate activations when a card is already in the field. Overall: ensures elements are correctly activated/deactivated (including prismatic cards) and avoids duplicate activations.