### PR TITLE
Add prismatic-perseverance support and slot handling

### DIFF
--- a/Scripts/CardManager.gd
+++ b/Scripts/CardManager.gd
@@ -257,10 +257,6 @@ func start_drag(card):
 		card.on_drag_start()
 	else:
 		card.rotation = 0.0
-	remove_card_from_rotated_slot(card)
-	remove_card_from_memory_slot(card)
-	remove_card_from_main_field(card)
-	remove_card_from_single_card_slot(card)
 	var graveyard_slot = get_graveyard_slot_for_card(card)
 	var banish_slot = get_banish_slot_for_card(card)
 	if graveyard_slot and graveyard_slot.has_method("get_top_card"):
@@ -290,10 +286,13 @@ func finish_drag():
 		card_being_dragged = null
 		return
 	_clear_memory_highlights()
-	free_card_from_slot(card)
 	if card.has_method("on_drag_end"):
 		card.on_drag_end()
 	var card_slot_found = raycast_check_for_card_single_slot()
+	var is_staying_on_mainfield = (drag_source_was_main_field and card_slot_found and card_slot_found.name == "MAINFIELD")
+	free_card_from_slot(card, is_staying_on_mainfield)
+	if drag_source_was_main_field and not is_staying_on_mainfield:
+		remove_card_from_main_field(card)
 	var is_banish_restricted = false
 	if dragged_from_grid and original_zone == "banish":
 		if card.has_method("is_champion_card") and card.is_champion_card():
@@ -540,7 +539,7 @@ func _return_mat_card_to_deck(card):
 		card.queue_free()
 	dragged_from_grid = false
 
-func free_card_from_slot(card):
+func free_card_from_slot(card, skip_mainfield = false):
 	if not card or not is_instance_valid(card):
 		return
 	if card.has_node("Area2D/CollisionShape2D"):
@@ -555,12 +554,13 @@ func free_card_from_slot(card):
 						if slot.has_property("card_in_slot"):
 							slot.card_in_slot = false
 						break
-	var all_nodes = get_tree().get_nodes_in_group("main_fields")
-	for node in all_nodes:
-		if node.name == "MAINFIELD" and is_instance_valid(node) and node.has_method("remove_card_from_field"):
-			if card in node.cards_in_field:
-				node.remove_card_from_field(card)
-				break
+	if not skip_mainfield:
+		var all_nodes = get_tree().get_nodes_in_group("main_fields")
+		for node in all_nodes:
+			if node.name == "MAINFIELD" and is_instance_valid(node) and node.has_method("remove_card_from_field"):
+				if card in node.cards_in_field:
+					node.remove_card_from_field(card)
+					break			
 	var single_card_slots = get_tree().get_nodes_in_group("single_card_slots")
 	for slot in single_card_slots:
 		if is_instance_valid(slot) and slot.has_method("remove_card_from_slot"):

--- a/Scripts/Main_Field.gd
+++ b/Scripts/Main_Field.gd
@@ -33,6 +33,11 @@ func activate_champion_elements(card):
 			var e_node = elements_node.get_node_or_null(e_name)
 			if e_node and e_node.has_method("activate"):
 				e_node.activate()
+	elif card_slug.contains("prismatic-perseverance"):
+		for e_name in ["Norm", "Fire", "Water", "Wind", "Astra", "Umbra", "Arcane", "Exia", "Crux", "Tera", "Neos", "Luxem"]:
+			var e_node = elements_node.get_node_or_null(e_name)
+			if e_node and e_node.has_method("activate"):
+				e_node.activate()
 	if is_champion_card(card):
 		var card_info_ref = find_card_information_reference()
 		if not card_info_ref or not card_info_ref.card_database_reference:
@@ -56,7 +61,7 @@ func deactivate_card_elements(card):
 	if not card or not is_instance_valid(card):
 		return
 	var card_slug = get_card_slug(card)
-	if not card_slug.contains("prismatic-sanctuary"):
+	if not (card_slug.contains("prismatic-sanctuary") or card_slug.contains("prismatic-perseverance")):
 		return
 	var root = get_tree().current_scene
 	var elements_node = get_parent().get_node_or_null("Elements")
@@ -64,7 +69,12 @@ func deactivate_card_elements(card):
 		if root and root.has_method("find_child"):
 			elements_node = root.find_child("Elements", true, false)	
 	if elements_node:
-		for e_name in ["Fire", "Water", "Wind"]:
+		var elements_to_deactivate = []
+		if card_slug.contains("prismatic-sanctuary"):
+			elements_to_deactivate = ["Fire", "Water", "Wind"]
+		elif card_slug.contains("prismatic-perseverance"):
+			elements_to_deactivate = ["Norm", "Fire", "Water", "Wind", "Astra", "Umbra", "Arcane", "Exia", "Crux", "Tera", "Neos", "Luxem"]
+		for e_name in elements_to_deactivate:
 			var e_node = elements_node.get_node_or_null(e_name)
 			if e_node and e_node.has_method("deactivate"):
 				e_node.deactivate()
@@ -133,7 +143,7 @@ func add_card_to_field(card, position = null):
 			current_mastery_card = card
 			cards_in_field.append(card)
 			card_in_slot = true
-			if get_card_slug(card).contains("prismatic-sanctuary"):
+			if get_card_slug(card).contains("prismatic-sanctuary") or get_card_slug(card).contains("prismatic-perseverance"):
 				activate_champion_elements(card)
 		if position != null:
 			card.global_position = position
@@ -153,7 +163,7 @@ func add_card_to_field(card, position = null):
 		if not (card in cards_in_field):
 			cards_in_field.append(card)
 			card_in_slot = true
-			if get_card_slug(card).contains("prismatic-sanctuary"):
+			if get_card_slug(card).contains("prismatic-sanctuary") or get_card_slug(card).contains("prismatic-perseverance"):
 				activate_champion_elements(card)
 		if card.has_method("set_current_field"):
 			card.set_current_field(self)

--- a/Scripts/OpponentMainField.gd
+++ b/Scripts/OpponentMainField.gd
@@ -56,9 +56,11 @@ func activate_champion_elements(card):
 			var e_node = elements_node.get_node_or_null("Opponent" + e_name)
 			if e_node and e_node.has_method("activate"):
 				e_node.activate()
-			elif e_node:
-				var sprite = e_node.get_node_or_null("Sprite2D")
-				if sprite: sprite.modulate.a = 1.0
+	elif card_slug.contains("prismatic-perseverance"):
+		for e_name in ["Norm", "Fire", "Water", "Wind", "Astra", "Umbra", "Arcane", "Exia", "Crux", "Tera", "Neos", "Luxem"]:
+			var e_node = elements_node.get_node_or_null("Opponent" + e_name)
+			if e_node and e_node.has_method("activate"):
+				e_node.activate()
 	if is_champion_card(card):
 		var element_name = ""
 		if card_info.has_method("get_card_element"):
@@ -68,17 +70,11 @@ func activate_champion_elements(card):
 				var norm = elements_node.get_node_or_null("OpponentNorm")
 				if norm and norm.has_method("activate"):
 					norm.activate()
-				elif norm:
-					var sprite = norm.get_node_or_null("Sprite2D")
-					if sprite: sprite.modulate.a = 1.0
 				first_champion_summoned = true
 			var capitalized_name = str(element_name).capitalize()
 			var element_node = elements_node.get_node_or_null("Opponent" + capitalized_name)
 			if element_node and element_node.has_method("activate"):
 				element_node.activate()
-			elif element_node:
-				var sprite = element_node.get_node_or_null("Sprite2D")
-				if sprite: sprite.modulate.a = 1.0
 
 func deactivate_card_elements(card):
 	if not card or not is_instance_valid(card):
@@ -86,7 +82,7 @@ func deactivate_card_elements(card):
 	var card_slug = ""
 	if card.has_meta("slug"):
 		card_slug = card.get_meta("slug")
-	if not card_slug.contains("prismatic-sanctuary"):
+	if not (card_slug.contains("prismatic-sanctuary") or card_slug.contains("prismatic-perseverance")):
 		return
 	var root = get_tree().current_scene
 	var elements_node = get_parent().get_node_or_null("OpponentElements")
@@ -94,13 +90,15 @@ func deactivate_card_elements(card):
 		if root:
 			elements_node = root.find_child("OpponentElements", true, false)	
 	if elements_node:
-		for e_name in ["Fire", "Water", "Wind"]:
+		var elements_to_deactivate = []
+		if card_slug.contains("prismatic-sanctuary"):
+			elements_to_deactivate = ["Fire", "Water", "Wind"]
+		elif card_slug.contains("prismatic-perseverance"):
+			elements_to_deactivate = ["Norm", "Fire", "Water", "Wind", "Astra", "Umbra", "Arcane", "Exia", "Crux", "Tera", "Neos", "Luxem"]
+		for e_name in elements_to_deactivate:
 			var e_node = elements_node.get_node_or_null("Opponent" + e_name)
 			if e_node and e_node.has_method("deactivate"):
 				e_node.deactivate()
-			elif e_node:
-				var sprite = e_node.get_node_or_null("Sprite2D")
-				if sprite: sprite.modulate.a = 0.0
 
 func notify_card_transformed(card: Node):
 	if is_champion_card(card):
@@ -181,13 +179,13 @@ func add_card_to_field(card: Node, target_pos: Vector2, target_rot_deg: float = 
 			remove_previous_mastery()
 		current_mastery_card = card
 		if not (card in cards_in_field):
-			if get_card_slug(card).contains("prismatic-sanctuary"):
+			if get_card_slug(card).contains("prismatic-sanctuary") or get_card_slug(card).contains("prismatic-perseverance"):
 				activate_champion_elements(card)
 	if card.has_method("set_current_field"):
 		card.set_current_field(self)
 	if card not in cards_in_field:
 		cards_in_field.append(card)
-		if get_card_slug(card).contains("prismatic-sanctuary") and not is_champion_card(card) and not is_mastery_card(card):
+		if (get_card_slug(card).contains("prismatic-sanctuary") or get_card_slug(card).contains("prismatic-perseverance")) and not is_champion_card(card) and not is_mastery_card(card):
 			activate_champion_elements(card)
 	var card_image = card.get_node_or_null("CardImage")
 	var card_image_back = card.get_node_or_null("CardImageBack")


### PR DESCRIPTION
Add support for the prismatic-perseverance champion by enabling activation/deactivation of its extended element list in Main_Field and OpponentMainField. Update add_card_to_field logic to treat prismatic-perseverance like prismatic-sanctuary when activating champion elements. Refactor CardManager.free_card_from_slot to accept a skip_mainfield flag, remove redundant slot removal calls from start_drag, and only remove a card from the main field during finish_drag when the card was dragged from the main field but did not remain on it. Small cleanup of element deactivation logic and related conditional checks.