### PR TITLE
Add Prismatic selection UI and element handling

### DIFF
--- a/Scripts/Card.gd
+++ b/Scripts/Card.gd
@@ -29,6 +29,7 @@ var selected_lineage_card_slug: String = ""
 var selected_lineage_card_uuid: String = ""
 var is_tweening: bool = false
 var original_owner_id = 0
+var chosen_elements := []
 var is_marked = false
 var _dynamic_transform_pairs := {}
 var _transform_pairs_initialized := false
@@ -438,6 +439,18 @@ func banish_lineage_card():
 	if banish_node == null:
 		return
 	var target_uuid = selected_lineage_card_uuid
+	if selected_lineage_card_slug.contains("prismatic-spirit"):
+		for entry in champion_lineage:
+			if entry.get("uuid", "") == target_uuid:
+				var chosen = entry.get("chosen_elements", [])
+				var scene_root = get_tree().current_scene
+				var elements = scene_root.find_child("Elements", true, false)
+				if elements:
+					for e_name in chosen:
+						var e_node = elements.get_node_or_null(e_name)
+						if e_node and e_node.has_method("deactivate"):
+							e_node.deactivate()
+				break
 	remove_from_lineage_by_uuid(target_uuid)
 	var card_scene = load("res://Scenes/Card.tscn")
 	var new_card = card_scene.instantiate()
@@ -487,7 +500,8 @@ func move_to_lineage():
 	var card_uuid = get_uuid()
 	var multiplayer_node = get_tree().get_root().get_node_or_null("Main")
 	if multiplayer_node and multiplayer_node.has_method("rpc"):
-		multiplayer_node.rpc("sync_move_to_lineage", multiplayer.get_unique_id(), champion.get_uuid(), card_uuid, card_slug)
+		var chosen = chosen_elements if chosen_elements.size() > 0 else []
+		multiplayer_node.rpc("sync_move_to_lineage", multiplayer.get_unique_id(), champion.get_uuid(), card_uuid, card_slug, chosen)
 	z_index = -1
 	var tween = create_tween()
 	tween.set_parallel(true)
@@ -495,7 +509,7 @@ func move_to_lineage():
 	tween.tween_property(self, "rotation_degrees", original_rotation, 0.5).set_trans(Tween.TRANS_QUAD).set_ease(Tween.EASE_IN_OUT)
 	tween.set_parallel(false)
 	tween.tween_callback(func():
-		var data = {"slug": card_slug, "uuid": card_uuid}
+		var data = {"slug": card_slug, "uuid": card_uuid, "chosen_elements": chosen_elements if chosen_elements.size() > 0 else []}
 		if champion.has_method("add_to_lineage"):
 			champion.add_to_lineage(data)
 		remove_from_current_position())
@@ -1474,6 +1488,7 @@ func _convert_to_opponent_card_visuals(final_pos, final_rot):
 		card_manager.add_child(new_opp_card)
 	new_opp_card.global_position = final_pos
 	new_opp_card.rotation_degrees = final_rot
+	new_opp_card.set_meta("is_given", true)
 	opp_main_field.add_card_to_field(new_opp_card, final_pos, final_rot)
 	var fix_tween = create_tween()
 	fix_tween.tween_property(new_opp_card, "rotation_degrees", final_rot, 0.2)

--- a/Scripts/Main_Field.gd
+++ b/Scripts/Main_Field.gd
@@ -7,6 +7,7 @@ var current_champion_card = null
 var current_mastery_card = null
 var champion_life_delta := 0
 var first_champion_summoned = false
+var imperial_seal_turn_count = 0
 
 func adjust_champion_life_delta(delta):
 	champion_life_delta += int(delta)
@@ -38,6 +39,39 @@ func activate_champion_elements(card):
 			var e_node = elements_node.get_node_or_null(e_name)
 			if e_node and e_node.has_method("activate"):
 				e_node.activate()
+	elif card_slug.contains("imperial-seal"):
+		if card.has_meta("is_given") and card.get_meta("is_given"):
+			card.set_meta("is_given", false)
+			return
+		imperial_seal_turn_count += 1
+		for e_name in ["Fire", "Water", "Wind"]:
+			var e_node = elements_node.get_node_or_null(e_name)
+			if e_node and e_node.has_method("activate"):
+				e_node.activate()
+	elif card_slug.contains("prismatic-spirit"):
+		var norm = elements_node.get_node_or_null("Norm")
+		if norm and norm.has_method("activate"):
+			norm.activate()
+		var original_owner = 0
+		if "original_owner_id" in card:
+			original_owner = card.original_owner_id
+		var my_id = 0
+		var multiplayer_node = get_tree().get_root().get_node_or_null("Main")
+		if multiplayer_node and multiplayer_node.has_method("multiplayer"):
+			my_id = multiplayer_node.multiplayer.get_unique_id()
+		elif multiplayer:
+			my_id = multiplayer.get_unique_id()
+		if original_owner == 0 or original_owner == my_id:
+			_show_prismatic_selection(card)
+	if "champion_lineage" in card:
+		for entry in card.champion_lineage:
+			var slug = entry.get("slug", "")
+			if slug.contains("prismatic-spirit"):
+				var chosen = entry.get("chosen_elements", [])
+				for e_name in chosen:
+					var e_node = elements_node.get_node_or_null(e_name)
+					if e_node and e_node.has_method("activate"):
+						e_node.activate()
 	if is_champion_card(card):
 		var card_info_ref = find_card_information_reference()
 		if not card_info_ref or not card_info_ref.card_database_reference:
@@ -61,8 +95,8 @@ func deactivate_card_elements(card):
 	if not card or not is_instance_valid(card):
 		return
 	var card_slug = get_card_slug(card)
-	if not (card_slug.contains("prismatic-sanctuary") or card_slug.contains("prismatic-perseverance")):
-		return
+	if not (card_slug.contains("prismatic-sanctuary") or card_slug.contains("prismatic-perseverance") or card_slug.contains("prismatic-spirit")):
+		pass
 	var root = get_tree().current_scene
 	var elements_node = get_parent().get_node_or_null("Elements")
 	if not elements_node:
@@ -78,6 +112,15 @@ func deactivate_card_elements(card):
 			var e_node = elements_node.get_node_or_null(e_name)
 			if e_node and e_node.has_method("deactivate"):
 				e_node.deactivate()
+		if "champion_lineage" in card:
+			for entry in card.champion_lineage:
+				var slug = entry.get("slug", "")
+				if slug.contains("prismatic-spirit"):
+					var chosen = entry.get("chosen_elements", [])
+					for e_name in chosen:
+						var e_node = elements_node.get_node_or_null(e_name)
+						if e_node and e_node.has_method("deactivate"):
+							e_node.deactivate()
 
 @warning_ignore("shadowed_variable_base_class")
 func add_card_to_field(card, position = null):
@@ -107,7 +150,8 @@ func add_card_to_field(card, position = null):
 				if card.has_method("add_to_lineage"):
 					var lineage_data = {
 						"slug": get_card_slug(current_champion_card),
-						"uuid": current_champion_card.uuid if "uuid" in current_champion_card else ""}
+						"uuid": current_champion_card.uuid if "uuid" in current_champion_card else "",
+						"chosen_elements": current_champion_card.chosen_elements if "chosen_elements" in current_champion_card else []}
 					card.add_to_lineage(lineage_data)
 				remove_previous_champions()
 			current_champion_card = card
@@ -143,7 +187,7 @@ func add_card_to_field(card, position = null):
 			current_mastery_card = card
 			cards_in_field.append(card)
 			card_in_slot = true
-			if get_card_slug(card).contains("prismatic-sanctuary") or get_card_slug(card).contains("prismatic-perseverance"):
+			if get_card_slug(card).contains("prismatic-sanctuary") or get_card_slug(card).contains("prismatic-perseverance") or get_card_slug(card).contains("imperial-seal"):
 				activate_champion_elements(card)
 		if position != null:
 			card.global_position = position
@@ -163,7 +207,7 @@ func add_card_to_field(card, position = null):
 		if not (card in cards_in_field):
 			cards_in_field.append(card)
 			card_in_slot = true
-			if get_card_slug(card).contains("prismatic-sanctuary") or get_card_slug(card).contains("prismatic-perseverance"):
+			if get_card_slug(card).contains("prismatic-sanctuary") or get_card_slug(card).contains("prismatic-perseverance") or get_card_slug(card).contains("imperial-seal"):
 				activate_champion_elements(card)
 		if card.has_method("set_current_field"):
 			card.set_current_field(self)
@@ -288,3 +332,31 @@ func clear_hovered_card():
 		var card = cards_in_field[i]
 		if card and is_instance_valid(card):
 			card.z_index = 200 + i + 1
+
+func clear_imperial_seal_activations():
+	var root = get_tree().current_scene
+	var elements_node = get_parent().get_node_or_null("Elements")
+	if not elements_node:
+		if root and root.has_method("find_child"):
+			elements_node = root.find_child("Elements", true, false)
+	if not elements_node:
+		imperial_seal_turn_count = 0
+		return
+	while imperial_seal_turn_count > 0:
+		for e_name in ["Fire", "Water", "Wind"]:
+			var e_node = elements_node.get_node_or_null(e_name)
+			if e_node and e_node.has_method("deactivate"):
+				e_node.deactivate()
+		imperial_seal_turn_count -= 1
+
+func _show_prismatic_selection(card):
+	var popup_script = load("res://Scripts/PrismaticSelectionPopup.gd")
+	if popup_script:
+		var popup = CanvasLayer.new()
+		popup.layer = 100
+		popup.set_script(popup_script)
+		get_tree().root.add_child(popup)
+		popup.selection_confirmed.connect(func(elements):
+			card.chosen_elements = elements
+			if card.has_meta("chosen_elements"):
+				card.set_meta("chosen_elements", elements))

--- a/Scripts/Multiplayer.gd
+++ b/Scripts/Multiplayer.gd
@@ -260,8 +260,17 @@ func show_turn_popup(message: String):
 
 @rpc("any_peer", "call_local", "reliable")
 func swap_turns():
-	is_my_turn = !is_my_turn
 	var player_field = get_node_or_null("PlayerField")
+	if player_field:
+		var main_field = player_field.get_node_or_null("MAINFIELD")
+		if main_field and main_field.has_method("clear_imperial_seal_activations"):
+			main_field.clear_imperial_seal_activations()
+	var opponent_field = get_node_or_null("OpponentField")
+	if opponent_field:
+		var opp_main_field = opponent_field.get_node_or_null("OpponentMainField")
+		if opp_main_field and opp_main_field.has_method("clear_imperial_seal_activations"):
+			opp_main_field.clear_imperial_seal_activations()
+	is_my_turn = !is_my_turn
 	if player_field:
 		var phases = player_field.get_node_or_null("Phases")
 		if phases:
@@ -923,7 +932,7 @@ func sync_banish_lineage_card(player_id: int, champion_uuid: String, lineage_uui
 		champion_card.animate_lineage_banish(lineage_slug, lineage_uuid)
 
 @rpc("any_peer", "reliable")
-func sync_move_to_lineage(player_id: int, champion_uuid: String, card_uuid: String, card_slug: String):
+func sync_move_to_lineage(player_id: int, champion_uuid: String, card_uuid: String, card_slug: String, chosen_elements: Array = []):
 	var is_from_remote = multiplayer.get_remote_sender_id() == player_id
 	if not is_from_remote:
 		return
@@ -937,7 +946,7 @@ func sync_move_to_lineage(player_id: int, champion_uuid: String, card_uuid: Stri
 	if not card_to_move:
 		pass
 	if champion_card.has_method("animate_send_to_lineage"):
-		champion_card.animate_send_to_lineage(card_to_move, card_slug, card_uuid)
+		champion_card.animate_send_to_lineage(card_to_move, card_slug, card_uuid, chosen_elements)
 
 @rpc("any_peer", "reliable")
 func sync_give_control(player_id: int, stats: Dictionary):
@@ -1118,6 +1127,7 @@ func _convert_opponent_to_player_card(opp_card: Node, stats: Dictionary, final_p
 	if card_manager.has_method("connect_card_signals"):
 		card_manager.connect_card_signals(new_card)
 	if main_field.has_method("add_card_to_field"):
+		new_card.set_meta("is_given", true)
 		main_field.add_card_to_field(new_card, final_pos)
 		var normalized_rot = fmod(final_rot, 360.0)
 		if normalized_rot < 0:

--- a/Scripts/OpponentCard.gd
+++ b/Scripts/OpponentCard.gd
@@ -16,6 +16,7 @@ var champion_lineage := []
 var selected_lineage_card_slug: String = ""
 var selected_lineage_card_uuid: String = ""
 var original_owner_id = 0
+var chosen_elements := []
 var is_marked = false
 var hold_timer = 0.0
 var is_holding_left = false
@@ -368,6 +369,19 @@ func _on_lineage_window_close():
 		lineage_view_window.hide()
 
 func animate_lineage_banish(slug: String, lineage_uuid: String):
+	if slug.contains("prismatic-spirit"):
+		for entry in champion_lineage:
+			if entry.get("uuid", "") == lineage_uuid:
+				var chosen = entry.get("chosen_elements", [])
+				var scene_root = get_tree().current_scene
+				var elements = scene_root.find_child("OpponentElements", true, false)
+				if elements:
+					for e_name in chosen:
+						var e_node = elements.get_node_or_null("Opponent" + e_name)
+						if e_node and e_node.has_method("deactivate"):
+							e_node.deactivate()
+				break
+
 	remove_from_lineage_by_uuid(lineage_uuid)
 	if lineage_view_window and lineage_view_window.visible:
 		open_lineage_window()
@@ -415,24 +429,24 @@ func animate_lineage_banish(slug: String, lineage_uuid: String):
 		else:
 			visual_card.queue_free())
 
-func animate_send_to_lineage(card_node: Node, card_slug: String, card_uuid: String):
+func animate_send_to_lineage(card_to_move: Node, card_slug: String, card_uuid: String, chosen_el: Array = []):
 	var final_callback = func():
-		add_to_lineage({"slug": card_slug, "uuid": card_uuid})
-		if card_node and is_instance_valid(card_node):
-			if card_node.get_parent():
-				if card_node.get_parent().has_method("remove_card_from_field"):
-					card_node.get_parent().remove_card_from_field(card_node)
-				elif card_node.get_parent().has_method("remove_card_from_slot"):
-					card_node.get_parent().remove_card_from_slot(card_node)
+		add_to_lineage({"slug": card_slug, "uuid": card_uuid, "chosen_elements": chosen_el})
+		if card_to_move and is_instance_valid(card_to_move):
+			if card_to_move.get_parent():
+				if card_to_move.get_parent().has_method("remove_card_from_field"):
+					card_to_move.get_parent().remove_card_from_field(card_to_move)
+				elif card_to_move.get_parent().has_method("remove_card_from_slot"):
+					card_to_move.get_parent().remove_card_from_slot(card_to_move)
 				else:
-					card_node.get_parent().remove_child(card_node)
-			card_node.queue_free()
-	if card_node and is_instance_valid(card_node):
-		card_node.z_index = 1000
+					card_to_move.get_parent().remove_child(card_to_move)
+			card_to_move.queue_free()
+	if card_to_move and is_instance_valid(card_to_move):
+		card_to_move.z_index = 1000
 		var tween = create_tween()
 		tween.set_parallel(true)
-		tween.tween_property(card_node, "global_position", global_position, 0.5).set_trans(Tween.TRANS_QUAD).set_ease(Tween.EASE_IN_OUT)
-		tween.tween_property(card_node, "rotation_degrees", 0.0, 0.5).set_trans(Tween.TRANS_QUAD).set_ease(Tween.EASE_IN_OUT)
+		tween.tween_property(card_to_move, "global_position", global_position, 0.5).set_trans(Tween.TRANS_QUAD).set_ease(Tween.EASE_IN_OUT)
+		tween.tween_property(card_to_move, "rotation_degrees", 0.0, 0.5).set_trans(Tween.TRANS_QUAD).set_ease(Tween.EASE_IN_OUT)
 		tween.set_parallel(false)
 		tween.tween_callback(final_callback)
 	else:

--- a/Scripts/OpponentMainField.gd
+++ b/Scripts/OpponentMainField.gd
@@ -5,6 +5,7 @@ var base_position := Vector2.ZERO
 var current_mastery_card: Node = null
 var current_champion_card: Node = null
 var first_champion_summoned = false
+var imperial_seal_turn_count = 0
 
 func is_champion_card(card) -> bool:
 	if not card or not is_instance_valid(card):
@@ -61,6 +62,28 @@ func activate_champion_elements(card):
 			var e_node = elements_node.get_node_or_null("Opponent" + e_name)
 			if e_node and e_node.has_method("activate"):
 				e_node.activate()
+	elif card_slug.contains("imperial-seal"):
+		if card.has_meta("is_given") and card.get_meta("is_given"):
+			card.set_meta("is_given", false)
+			return
+		imperial_seal_turn_count += 1
+		for e_name in ["Fire", "Water", "Wind"]:
+			var e_node = elements_node.get_node_or_null("Opponent" + e_name)
+			if e_node and e_node.has_method("activate"):
+				e_node.activate()
+	elif card_slug.contains("prismatic-spirit"):
+		var norm = elements_node.get_node_or_null("OpponentNorm")
+		if norm and norm.has_method("activate"):
+			norm.activate()
+	if "champion_lineage" in card:
+		for entry in card.champion_lineage:
+			var slug = entry.get("slug", "")
+			if slug.contains("prismatic-spirit"):
+				var chosen = entry.get("chosen_elements", [])
+				for e_name in chosen:
+					var e_node = elements_node.get_node_or_null("Opponent" + e_name)
+					if e_node and e_node.has_method("activate"):
+						e_node.activate()
 	if is_champion_card(card):
 		var element_name = ""
 		if card_info.has_method("get_card_element"):
@@ -82,7 +105,9 @@ func deactivate_card_elements(card):
 	var card_slug = ""
 	if card.has_meta("slug"):
 		card_slug = card.get_meta("slug")
-	if not (card_slug.contains("prismatic-sanctuary") or card_slug.contains("prismatic-perseverance")):
+	if not (card_slug.contains("prismatic-sanctuary") or card_slug.contains("prismatic-perseverance") or card_slug.contains("prismatic-spirit")):
+		pass
+	if card_slug.contains("imperial-seal"):
 		return
 	var root = get_tree().current_scene
 	var elements_node = get_parent().get_node_or_null("OpponentElements")
@@ -121,7 +146,7 @@ func notify_card_transformed(card: Node):
 			if "runtime_modifiers" in current_champion_card:
 				card.runtime_modifiers = current_champion_card.runtime_modifiers.duplicate()
 			if card.has_method("add_to_lineage"):
-				card.add_to_lineage({"slug": old_slug, "uuid": old_uuid})
+				card.add_to_lineage({"slug": old_slug, "uuid": old_uuid, "chosen_elements": current_champion_card.chosen_elements if "chosen_elements" in current_champion_card else []})
 			remove_previous_champions()
 		current_champion_card = card
 		if not (card in cards_in_field):
@@ -168,7 +193,7 @@ func add_card_to_field(card: Node, target_pos: Vector2, target_rot_deg: float = 
 			if "runtime_modifiers" in current_champion_card:
 				card.runtime_modifiers = current_champion_card.runtime_modifiers.duplicate()
 			if card.has_method("add_to_lineage"):
-				card.add_to_lineage({"slug": old_slug, "uuid": old_uuid})
+				card.add_to_lineage({"slug": old_slug, "uuid": old_uuid, "chosen_elements": current_champion_card.chosen_elements if "chosen_elements" in current_champion_card else []})
 			remove_previous_champions()
 		current_champion_card = card
 		if not (card in cards_in_field):
@@ -179,13 +204,13 @@ func add_card_to_field(card: Node, target_pos: Vector2, target_rot_deg: float = 
 			remove_previous_mastery()
 		current_mastery_card = card
 		if not (card in cards_in_field):
-			if get_card_slug(card).contains("prismatic-sanctuary") or get_card_slug(card).contains("prismatic-perseverance"):
+			if get_card_slug(card).contains("prismatic-sanctuary") or get_card_slug(card).contains("prismatic-perseverance") or get_card_slug(card).contains("imperial-seal"):
 				activate_champion_elements(card)
 	if card.has_method("set_current_field"):
 		card.set_current_field(self)
 	if card not in cards_in_field:
 		cards_in_field.append(card)
-		if (get_card_slug(card).contains("prismatic-sanctuary") or get_card_slug(card).contains("prismatic-perseverance")) and not is_champion_card(card) and not is_mastery_card(card):
+		if (get_card_slug(card).contains("prismatic-sanctuary") or get_card_slug(card).contains("prismatic-perseverance") or get_card_slug(card).contains("imperial-seal")) and not is_champion_card(card) and not is_mastery_card(card):
 			activate_champion_elements(card)
 	var card_image = card.get_node_or_null("CardImage")
 	var card_image_back = card.get_node_or_null("CardImageBack")
@@ -249,6 +274,22 @@ func clear_hovered_card() -> void:
 		var card = cards_in_field[i]
 		if card and is_instance_valid(card):
 			card.z_index = 200 + i + 1
+
+func clear_imperial_seal_activations():
+	var root = get_tree().current_scene
+	var elements_node = get_parent().get_node_or_null("OpponentElements")
+	if not elements_node:
+		if root:
+			elements_node = root.find_child("OpponentElements", true, false)	
+	if not elements_node:
+		imperial_seal_turn_count = 0
+		return
+	while imperial_seal_turn_count > 0:
+		for e_name in ["Fire", "Water", "Wind"]:
+			var e_node = elements_node.get_node_or_null("Opponent" + e_name)
+			if e_node and e_node.has_method("deactivate"):
+				e_node.deactivate()
+		imperial_seal_turn_count -= 1
 
 func connect_card_signals(card):
 	var card_manager = get_tree().get_root().find_child("CardManager", true, false)

--- a/Scripts/PrismaticSelectionPopup.gd
+++ b/Scripts/PrismaticSelectionPopup.gd
@@ -1,0 +1,86 @@
+extends CanvasLayer
+
+signal selection_confirmed(elements)
+
+var selected_elements := []
+var confirm_button: Button
+var element_buttons := {}
+var panel: PanelContainer
+
+func _ready():
+	panel = PanelContainer.new()
+	panel.custom_minimum_size = Vector2(400, 250)
+	panel.set_anchor(SIDE_LEFT, 0.5)
+	panel.set_anchor(SIDE_TOP, 0.5)
+	panel.set_anchor(SIDE_RIGHT, 0.5)
+	panel.set_anchor(SIDE_BOTTOM, 0.5)
+	panel.grow_horizontal = Control.GROW_DIRECTION_BOTH
+	panel.grow_vertical = Control.GROW_DIRECTION_BOTH
+	var style = StyleBoxFlat.new()
+	style.bg_color = Color(0.15, 0.15, 0.15, 1.0)
+	style.set_border_width_all(2)
+	style.border_color = Color(0.4, 0.4, 0.4)
+	style.set_corner_radius_all(10)
+	panel.add_theme_stylebox_override("panel", style)
+	add_child(panel)
+	var margin = MarginContainer.new()
+	margin.add_theme_constant_override("margin_top", 20)
+	margin.add_theme_constant_override("margin_bottom", 20)
+	margin.add_theme_constant_override("margin_left", 20)
+	margin.add_theme_constant_override("margin_right", 20)
+	panel.add_child(margin)
+	var vbox = VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 15)
+	margin.add_child(vbox)
+	var title = Label.new()
+	title.text = "Prismatic Spirit: Choose 2 Elements"
+	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	vbox.add_child(title)
+	var hbox = HBoxContainer.new()
+	hbox.alignment = BoxContainer.ALIGNMENT_CENTER
+	hbox.add_theme_constant_override("separation", 20)
+	vbox.add_child(hbox)
+	for e_name in ["Fire", "Water", "Wind"]:
+		var btn = Button.new()
+		btn.text = e_name
+		btn.toggle_mode = true
+		btn.custom_minimum_size = Vector2(100, 50)
+		btn.pressed.connect(func(): _on_element_toggled(e_name))
+		hbox.add_child(btn)
+		element_buttons[e_name] = btn
+	confirm_button = Button.new()
+	confirm_button.text = "Confirm"
+	confirm_button.disabled = true
+	confirm_button.custom_minimum_size = Vector2(150, 40)
+	confirm_button.size_flags_horizontal = Control.SIZE_SHRINK_CENTER
+	confirm_button.pressed.connect(_on_confirm_pressed)
+	vbox.add_child(confirm_button)
+
+func _input(event):
+	if event is InputEventMouse:
+		var mouse_pos = event.global_position
+		var over_button = false
+		for btn in element_buttons.values():
+			if btn.get_global_rect().has_point(mouse_pos):
+				over_button = true
+				break
+		if confirm_button and confirm_button.get_global_rect().has_point(mouse_pos):
+			over_button = true
+		if not over_button:
+			get_viewport().set_input_as_handled()
+
+func _on_element_toggled(element_name: String):
+	var btn = element_buttons[element_name]
+	if btn.button_pressed:
+		if selected_elements.size() >= 2:
+			var oldest = selected_elements.pop_front()
+			if element_buttons.has(oldest):
+				element_buttons[oldest].button_pressed = false
+		selected_elements.append(element_name)
+	else:
+		selected_elements.erase(element_name)
+	confirm_button.disabled = (selected_elements.size() != 2)
+
+func _on_confirm_pressed():
+	emit_signal("selection_confirmed", selected_elements)
+	queue_free()

--- a/Scripts/PrismaticSelectionPopup.gd.uid
+++ b/Scripts/PrismaticSelectionPopup.gd.uid
@@ -1,0 +1,1 @@
+uid://bkx282j8n3h1l


### PR DESCRIPTION
Introduce a PrismaticSelectionPopup for choosing two elements and track chosen_elements on cards and opponent cards. Propagate chosen_elements when sending cards to lineage (local and via RPC) and apply activation/deactivation for prismatic-spirit entries. Add imperial_seal turn tracking and clear activations on turn swap for both player and opponent main fields. Mark cards transferred between fields as "is_given" to avoid re-triggering effects. Minor cleanup and variable additions to support these behaviors.