### PR TITLE
Add 'status' card type support and UI

### DIFF
--- a/Scenes/Elements.tscn
+++ b/Scenes/Elements.tscn
@@ -17,60 +17,60 @@
 [node name="Elements" type="Node2D" unique_id=751180445]
 
 [node name="Norm" parent="." unique_id=1666109979 instance=ExtResource("1_4u5m1")]
-position = Vector2(560, 580)
+position = Vector2(52, 1114)
 scale = Vector2(0.45, 0.45)
 script = ExtResource("2_5fnqk")
 
 [node name="Fire" parent="." unique_id=374077020 instance=ExtResource("3_kck3e")]
-position = Vector2(560, 615)
+position = Vector2(52, 1149)
 scale = Vector2(0.45, 0.45)
 script = ExtResource("2_5fnqk")
 
 [node name="Water" parent="." unique_id=723149034 instance=ExtResource("4_vlsow")]
-position = Vector2(560, 650)
+position = Vector2(52, 1184)
 scale = Vector2(0.45, 0.45)
 script = ExtResource("2_5fnqk")
 
 [node name="Wind" parent="." unique_id=1176706118 instance=ExtResource("5_eiivs")]
-position = Vector2(560, 685)
+position = Vector2(52, 1219)
 scale = Vector2(0.45, 0.45)
 script = ExtResource("2_5fnqk")
 
 [node name="Astra" parent="." unique_id=2015843059 instance=ExtResource("6_vpct8")]
-position = Vector2(595, 580)
+position = Vector2(87, 1114)
 scale = Vector2(0.38, 0.38)
 script = ExtResource("2_5fnqk")
 
 [node name="Umbra" parent="." unique_id=434383752 instance=ExtResource("7_82vsi")]
-position = Vector2(630, 580)
+position = Vector2(122, 1114)
 scale = Vector2(0.38, 0.38)
 script = ExtResource("2_5fnqk")
 
 [node name="Arcane" parent="." unique_id=1952007852 instance=ExtResource("8_usnql")]
-position = Vector2(595, 615)
+position = Vector2(87, 1149)
 scale = Vector2(0.45, 0.45)
 script = ExtResource("2_5fnqk")
 
 [node name="Exia" parent="." unique_id=2073190595 instance=ExtResource("9_bchgv")]
-position = Vector2(630, 615)
+position = Vector2(122, 1149)
 scale = Vector2(0.38, 0.38)
 script = ExtResource("2_5fnqk")
 
 [node name="Crux" parent="." unique_id=1668994294 instance=ExtResource("10_tgia7")]
-position = Vector2(595, 650)
+position = Vector2(87, 1184)
 scale = Vector2(0.45, 0.45)
 
 [node name="Tera" parent="." unique_id=2060848043 instance=ExtResource("11_xtxi3")]
-position = Vector2(595, 685)
+position = Vector2(87, 1219)
 scale = Vector2(0.38, 0.38)
 script = ExtResource("2_5fnqk")
 
 [node name="Neos" parent="." unique_id=1425423060 instance=ExtResource("12_8csf3")]
-position = Vector2(630, 685)
+position = Vector2(122, 1219)
 scale = Vector2(0.38, 0.38)
 script = ExtResource("2_5fnqk")
 
 [node name="Luxem" parent="." unique_id=912093786 instance=ExtResource("13_0ue1h")]
-position = Vector2(630, 650)
+position = Vector2(122, 1184)
 scale = Vector2(0.38, 0.38)
 script = ExtResource("2_5fnqk")

--- a/Scenes/Logo.tscn
+++ b/Scenes/Logo.tscn
@@ -1,77 +1,95 @@
-[gd_scene load_steps=2 format=3 uid="uid://c3x07o1r7glog"]
+[gd_scene format=3 uid="uid://c3x07o1r7glog"]
 
 [ext_resource type="PackedScene" uid="uid://bjmf6g1notrh7" path="res://Scenes/CardDisplay.tscn" id="1_gukjj"]
 
-[node name="Logo" type="Node2D"]
+[node name="Logo" type="Node2D" unique_id=516982437]
 
-[node name="Area2D" type="Area2D" parent="."]
+[node name="Area2D" type="Area2D" parent="." unique_id=1188845047]
 collision_layer = 32
 collision_mask = 32
 
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Area2D"]
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Area2D" unique_id=861766340]
 polygon = PackedVector2Array(-3, -35, -9, -29, -38, -19, -45, -23, -44, -7, -56, 15, -50, 24, -34, 30, -8, 25, -4, 36, 1, 25, 27, 31, 43, 26, 50, 16, 38, -7, 39, -22, 31, -20, 3, -29)
 
-[node name="LogoMenu" type="PanelContainer" parent="."]
+[node name="LogoMenu" type="PanelContainer" parent="." unique_id=1101697654]
 visible = false
 z_index = 2000
 
-[node name="MainVBox" type="VBoxContainer" parent="LogoMenu"]
+[node name="MainVBox" type="VBoxContainer" parent="LogoMenu" unique_id=1094107958]
 layout_mode = 2
 theme_override_constants/separation = 0
 
-[node name="ScrollSection" type="ScrollContainer" parent="LogoMenu/MainVBox"]
+[node name="ScrollSection" type="ScrollContainer" parent="LogoMenu/MainVBox" unique_id=1460488530]
 layout_mode = 2
 size_flags_vertical = 0
 horizontal_scroll_mode = 0
 
-[node name="ScrollVBox" type="VBoxContainer" parent="LogoMenu/MainVBox/ScrollSection"]
+[node name="ScrollVBox" type="VBoxContainer" parent="LogoMenu/MainVBox/ScrollSection" unique_id=533039558]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 0
 theme_override_constants/separation = 0
 
-[node name="Separator" type="HSeparator" parent="LogoMenu/MainVBox"]
+[node name="Separator" type="HSeparator" parent="LogoMenu/MainVBox" unique_id=489742845]
 visible = false
 layout_mode = 2
 theme_override_constants/separation = 0
 
-[node name="FixedVBox" type="VBoxContainer" parent="LogoMenu/MainVBox"]
+[node name="FixedVBox" type="VBoxContainer" parent="LogoMenu/MainVBox" unique_id=574980550]
 layout_mode = 2
 size_flags_vertical = 0
 theme_override_constants/separation = 0
 
-[node name="LogoViewWindow" type="Window" parent="."]
+[node name="LogoViewWindow" type="Window" parent="." unique_id=1676907393]
 auto_translate_mode = 1
 size = Vector2i(600, 142)
 visible = false
 unresizable = true
 
-[node name="ScrollContainer" type="ScrollContainer" parent="LogoViewWindow"]
+[node name="ScrollContainer" type="ScrollContainer" parent="LogoViewWindow" unique_id=672891432]
 offset_right = 600.0
 offset_bottom = 142.0
 
-[node name="GridContainer" type="GridContainer" parent="LogoViewWindow/ScrollContainer"]
+[node name="GridContainer" type="GridContainer" parent="LogoViewWindow/ScrollContainer" unique_id=1427530111]
 custom_minimum_size = Vector2(600, 142)
 layout_mode = 2
 columns = 1024
 
-[node name="Control" parent="LogoViewWindow/ScrollContainer/GridContainer" instance=ExtResource("1_gukjj")]
+[node name="Control" parent="LogoViewWindow/ScrollContainer/GridContainer" unique_id=1192546635 instance=ExtResource("1_gukjj")]
 layout_mode = 2
 
-[node name="LogoMasteryViewWindow" type="Window" parent="."]
+[node name="LogoMasteryViewWindow" type="Window" parent="." unique_id=544854343]
 auto_translate_mode = 1
 size = Vector2i(600, 142)
 visible = false
 unresizable = true
 
-[node name="ScrollContainer" type="ScrollContainer" parent="LogoMasteryViewWindow"]
+[node name="ScrollContainer" type="ScrollContainer" parent="LogoMasteryViewWindow" unique_id=531211145]
 offset_right = 600.0
 offset_bottom = 142.0
 
-[node name="GridContainer" type="GridContainer" parent="LogoMasteryViewWindow/ScrollContainer"]
+[node name="GridContainer" type="GridContainer" parent="LogoMasteryViewWindow/ScrollContainer" unique_id=588084443]
 custom_minimum_size = Vector2(600, 142)
 layout_mode = 2
 columns = 1024
 
-[node name="Control" parent="LogoMasteryViewWindow/ScrollContainer/GridContainer" instance=ExtResource("1_gukjj")]
+[node name="Control" parent="LogoMasteryViewWindow/ScrollContainer/GridContainer" unique_id=425910120 instance=ExtResource("1_gukjj")]
+layout_mode = 2
+
+[node name="LogoStatusViewWindow" type="Window" parent="." unique_id=1022757827]
+auto_translate_mode = 1
+size = Vector2i(600, 142)
+visible = false
+unresizable = true
+
+[node name="ScrollContainer" type="ScrollContainer" parent="LogoStatusViewWindow" unique_id=335808166]
+offset_right = 600.0
+offset_bottom = 142.0
+
+[node name="GridContainer" type="GridContainer" parent="LogoStatusViewWindow/ScrollContainer" unique_id=1977355046]
+custom_minimum_size = Vector2(600, 142)
+layout_mode = 2
+columns = 1024
+
+[node name="Control" parent="LogoStatusViewWindow/ScrollContainer/GridContainer" unique_id=797281537 instance=ExtResource("1_gukjj")]
 layout_mode = 2

--- a/Scenes/Opponent_Elements.tscn
+++ b/Scenes/Opponent_Elements.tscn
@@ -17,60 +17,60 @@
 [node name="OpponentElements" type="Node2D" unique_id=71210036]
 
 [node name="OpponentNorm" parent="." unique_id=978366412 instance=ExtResource("1_6ql4t")]
-position = Vector2(1397, 500)
+position = Vector2(130, 1228)
 scale = Vector2(0.45, 0.45)
 script = ExtResource("13_6ql4t")
 
 [node name="OpponentFire" parent="." unique_id=1114004685 instance=ExtResource("2_1n4dq")]
-position = Vector2(1397, 465)
+position = Vector2(130, 1193)
 scale = Vector2(0.45, 0.45)
 script = ExtResource("13_6ql4t")
 
 [node name="OpponentWater" parent="." unique_id=910883526 instance=ExtResource("3_j7acn")]
-position = Vector2(1397, 430)
+position = Vector2(130, 1158)
 scale = Vector2(0.45, 0.45)
 script = ExtResource("13_6ql4t")
 
 [node name="OpponentWind" parent="." unique_id=831720720 instance=ExtResource("4_sec3a")]
-position = Vector2(1397, 395)
+position = Vector2(130, 1123)
 scale = Vector2(0.45, 0.45)
 script = ExtResource("13_6ql4t")
 
 [node name="OpponentAstra" parent="." unique_id=319612498 instance=ExtResource("5_7yc41")]
-position = Vector2(1362, 500)
+position = Vector2(95, 1228)
 scale = Vector2(0.38, 0.38)
 script = ExtResource("13_6ql4t")
 
 [node name="OpponentUmbra" parent="." unique_id=1612739560 instance=ExtResource("6_xiib5")]
-position = Vector2(1327, 500)
+position = Vector2(60, 1228)
 scale = Vector2(0.38, 0.38)
 script = ExtResource("13_6ql4t")
 
 [node name="OpponentArcane" parent="." unique_id=367524322 instance=ExtResource("7_g3co2")]
-position = Vector2(1362, 465)
+position = Vector2(95, 1193)
 scale = Vector2(0.45, 0.45)
 script = ExtResource("13_6ql4t")
 
 [node name="OpponentExia" parent="." unique_id=234824515 instance=ExtResource("8_y5yek")]
-position = Vector2(1327, 465)
+position = Vector2(60, 1193)
 scale = Vector2(0.38, 0.38)
 script = ExtResource("13_6ql4t")
 
 [node name="OpponentCrux" parent="." unique_id=326146833 instance=ExtResource("9_gimyw")]
-position = Vector2(1362, 430)
+position = Vector2(95, 1158)
 scale = Vector2(0.45, 0.45)
 
 [node name="OpponentTera" parent="." unique_id=765129002 instance=ExtResource("10_hldlb")]
-position = Vector2(1362, 395)
+position = Vector2(95, 1123)
 scale = Vector2(0.38, 0.38)
 script = ExtResource("13_6ql4t")
 
 [node name="OpponentNeos" parent="." unique_id=40823860 instance=ExtResource("11_q7drv")]
-position = Vector2(1327, 395)
+position = Vector2(60, 1123)
 scale = Vector2(0.38, 0.38)
 script = ExtResource("13_6ql4t")
 
 [node name="OpponentLuxem" parent="." unique_id=1607869790 instance=ExtResource("12_td0eo")]
-position = Vector2(1327, 430)
+position = Vector2(60, 1158)
 scale = Vector2(0.38, 0.38)
 script = ExtResource("13_6ql4t")

--- a/Scripts/Card.gd
+++ b/Scripts/Card.gd
@@ -274,6 +274,13 @@ func _on_area_2d_input_event(_viewport: Node, event: InputEvent, _shape_idx: int
 						var target_slug = get_transform_target(slug)
 						if not is_slug_champion(target_slug) or (original_owner_id == 0 or original_owner_id == multiplayer.get_unique_id()):
 							popup_menu.add_item("Transform", 5)
+			elif is_status():
+				if is_in_main_field():
+					popup_menu.add_item("Destroy", 8)
+					if is_rotated:
+						popup_menu.add_item("Awake", 4)
+					else:
+						popup_menu.add_item("Rest", 4)
 			else:
 				if is_in_memory_slot() or is_in_hand():
 					if not is_publicly_revealed:
@@ -297,12 +304,12 @@ func _on_area_2d_input_event(_viewport: Node, event: InputEvent, _shape_idx: int
 						popup_menu.add_item("Awake", 4)
 					else:
 						popup_menu.add_item("Rest", 4)
-					if not is_champion_card() and not is_token() and not is_mastery():
+					if not is_champion_card() and not is_token() and not is_mastery() and not is_status():
 						if current_field and current_field.name == "MAINFIELD":
 							if (original_owner_id == 0 or original_owner_id == multiplayer.get_unique_id()):
 								if "current_champion_card" in current_field and current_field.current_champion_card != null:
 									popup_menu.add_item("Move to Lineage", 14)
-					if not is_champion_card() and not is_token() and not is_mastery():
+					if not is_champion_card() and not is_token() and not is_mastery() and not is_status():
 						var opponent_field = get_tree().get_root().find_child("OpponentField", true, false)
 						if opponent_field:
 							popup_menu.add_item("Give Control", 15)
@@ -726,6 +733,7 @@ func _on_PopupMenu_id_pressed(id: int) -> void:
 		5: transform_card()
 		6: destroy_token()
 		7: destroy_mastery()
+		8: destroy_status()
 		10: reveal_to_opponent()
 		11: hide_from_opponent()
 		12: reveal_all_in_memory()
@@ -792,6 +800,9 @@ func set_current_field(field):
 		return
 	if is_mastery() and field and (field.is_in_group("player_hand") or field.is_in_group("single_card_slots") or field.is_in_group("rotated_slots") or field.is_in_group("memory_slots")):
 		destroy_mastery()
+		return
+	if is_status() and field and (field.is_in_group("player_hand") or field.is_in_group("single_card_slots") or field.is_in_group("rotated_slots") or field.is_in_group("memory_slots")):
+		destroy_status()
 		return
 	if is_marked and current_field != null and field != null:
 		if current_field != field:
@@ -1205,6 +1216,28 @@ func destroy_mastery():
 	var multiplayer_node = get_tree().get_root().get_node("Main")
 	if multiplayer_node and multiplayer_node.has_method("rpc"):
 		multiplayer_node.rpc("sync_destroy_mastery", multiplayer.get_unique_id(), get_uuid(), slug)
+	if current_field and current_field.has_method("remove_card_from_field"):
+		current_field.remove_card_from_field(self)
+	elif current_field and current_field.has_method("remove_card_from_slot"):
+		current_field.remove_card_from_slot(self)
+	queue_free()
+
+func is_status() -> bool:
+	var slug = get_slug_from_card()
+	var logos = get_tree().get_nodes_in_group("logo")
+	if logos.size() > 0:
+		var logo = logos[0]
+		if logo.has_method("get") and "status_slugs" in logo:
+			return slug in logo.status_slugs
+		elif logo.get("status_slugs") != null:
+			return slug in logo.status_slugs
+	return false
+
+func destroy_status():
+	var slug = get_slug_from_card()
+	var multiplayer_node = get_tree().get_root().get_node("Main")
+	if multiplayer_node and multiplayer_node.has_method("rpc"):
+		multiplayer_node.rpc("sync_destroy_token", multiplayer.get_unique_id(), get_uuid(), slug)
 	if current_field and current_field.has_method("remove_card_from_field"):
 		current_field.remove_card_from_field(self)
 	elif current_field and current_field.has_method("remove_card_from_slot"):

--- a/Scripts/CardDisplay.gd
+++ b/Scripts/CardDisplay.gd
@@ -150,7 +150,7 @@ func _gui_input(event):
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
 		if zone == "lineage":
 			return
-		if zone in ["graveyard", "banish", "ga_deck", "mat_deck", "logo_tokens", "logo_mastery", "lineage"]:
+		if zone in ["graveyard", "banish", "ga_deck", "mat_deck", "logo_tokens", "logo_mastery", "logo_status", "lineage"]:
 			var current_uuid = get_meta("uuid") if has_meta("uuid") else ""
 			emit_signal("request_popup_menu", card_slug, current_uuid)
 			accept_event()
@@ -201,7 +201,7 @@ func start_drag_from_grid():
 		if card_manager and card_manager.has_method("start_drag"):
 			card_manager.start_drag(real_card)
 			card_manager.set_dragged_from_grid_info(card_slug, zone, self)
-			if zone != "logo_tokens" and zone != "logo_mastery":
+			if zone != "logo_tokens" and zone != "logo_mastery" and zone != "logo_status":
 				if zone == "lineage":
 					var owner_node = get_parent()
 					while owner_node != null and not owner_node.has_method("remove_from_lineage_by_uuid"):
@@ -234,7 +234,7 @@ func start_drag_from_grid():
 				if texture_rect and texture_rect.texture:
 					face_down = "ga_back.png" in texture_rect.texture.resource_path
 				card_manager.set_dragged_from_grid_info(card_slug, zone, self, grid_index, source_node, face_down, left_uuid, right_uuid)
-				if zone != "logo_tokens" and zone != "logo_mastery":
+				if zone != "logo_tokens" and zone != "logo_mastery" and zone != "logo_status":
 					if zone == "lineage":
 						pass
 					update_grid_immediately()

--- a/Scripts/CardManager.gd
+++ b/Scripts/CardManager.gd
@@ -356,6 +356,13 @@ func finish_drag():
 			_return_mat_card_to_deck(card)
 			_reset_drag_state_vars()
 			return
+		if card.has_method("is_status") and card.is_status() and card_slot_found.name != "MAINFIELD":
+			if card.has_method("destroy_status"):
+				card.destroy_status()
+			else:
+				card.queue_free()
+			_reset_drag_state_vars()
+			return
 		if dragged_from_grid:
 			remove_card_from_original_slot()
 			dragged_from_grid = false
@@ -388,6 +395,21 @@ func finish_drag():
 			card.scale = normal_scale
 			card.z_index = base_z_index
 		elif card_slot_found.name == "MAINFIELD":
+			if card.has_method("is_status") and card.is_status():
+				var c_slug = get_card_slug(card)
+				var c_name = get_card_name_from_slug(c_slug)
+				if c_name != "":
+					var to_destroy = []
+					for c in card_slot_found.cards_in_field:
+						if c != card and c.has_method("is_status") and c.is_status():
+							var existing_name = get_card_name_from_slug(get_card_slug(c))
+							if existing_name != "" and existing_name == c_name:
+								to_destroy.append(c)
+					for c in to_destroy:
+						if c.has_method("destroy_status"):
+							c.destroy_status()
+						else:
+							c.queue_free()
 			var is_first_card = card_slot_found.cards_in_field.is_empty()
 			var drop_position = null
 			if not is_first_card:
@@ -461,6 +483,13 @@ func finish_drag():
 			original_slug = ""
 			original_zone = ""
 			original_card_display = null
+		if card.has_method("is_status") and card.is_status():
+			if card.has_method("destroy_status"):
+				card.destroy_status()
+			else:
+				card.queue_free()
+			_reset_drag_state_vars()
+			return
 		if player_hand_reference:
 			var was_in_hand = (player_hand_reference.dragging_card_from_hand == card)
 			player_hand_reference.add_card_to_hand(card)
@@ -1049,6 +1078,28 @@ func get_card_slug(card) -> String:
 	if card.has_meta("slug"):
 		return card.get_meta("slug")
 	return ""
+
+func get_card_name_from_slug(slug: String) -> String:
+	if slug == "":
+		return ""
+	var card_info = card_information_reference
+	if not card_info:
+		card_info = find_card_information_reference()
+	if card_info and card_info.get("card_database_reference"):
+		var db = card_info.card_database_reference
+		if db and db.get("cards_db"):
+			if db.cards_db.has(slug):
+				var data = db.cards_db[slug]
+				if data.has("name"):
+					return str(data["name"])
+			for key in db.cards_db:
+				var data = db.cards_db[key]
+				if data.has("editions"):
+					for edition in data["editions"]:
+						if edition.get("slug", "") == slug:
+							if data.has("name"):
+								return str(data["name"])
+	return slug
 
 func get_card_uuid(card) -> String:
 	if "uuid" in card and card.uuid != "":

--- a/Scripts/Logo.gd
+++ b/Scripts/Logo.gd
@@ -9,6 +9,8 @@ extends Node2D
 @onready var grid_container = $LogoViewWindow/ScrollContainer/GridContainer
 @onready var Logo_mastery_view_window = $LogoMasteryViewWindow
 @onready var mastery_grid_container = $LogoMasteryViewWindow/ScrollContainer/GridContainer
+@onready var Logo_status_view_window = $LogoStatusViewWindow
+@onready var status_grid_container = $LogoStatusViewWindow/ScrollContainer/GridContainer
 
 var level_label: Label
 var durability_label: Label
@@ -37,6 +39,7 @@ var original_menu_pos: Vector2 = Vector2.ZERO
 var player_name: String = "Player"
 var token_slugs : Array = []
 var mastery_slugs : Array = []
+var status_slugs : Array = []
 
 func _ready():
 	add_to_group("logo")
@@ -57,10 +60,14 @@ func _ready():
 	Logo_view_window.visibility_changed.connect(_on_logo_view_visibility_changed)
 	Logo_mastery_view_window.close_requested.connect(_on_logo_mastery_view_close)
 	Logo_mastery_view_window.visibility_changed.connect(_on_logo_mastery_view_visibility_changed)
+	Logo_status_view_window.close_requested.connect(_on_logo_status_view_close)
+	Logo_status_view_window.visibility_changed.connect(_on_logo_status_view_visibility_changed)
 	call_deferred("populate_tokens")
 	call_deferred("populate_mastery")
+	call_deferred("populate_status")
 	Logo_view_window.hide()
 	Logo_mastery_view_window.hide()
+	Logo_status_view_window.hide()
 	var config = ConfigFile.new()
 	var err = config.load("user://player_config.cfg")
 	if err == OK:
@@ -116,6 +123,14 @@ func _on_logo_mastery_view_visibility_changed():
 	if Logo_mastery_view_window.visible:
 		$LogoMasteryViewWindow/ScrollContainer.scroll_horizontal = 0
 		$LogoMasteryViewWindow/ScrollContainer.scroll_vertical = 0
+
+func _on_logo_status_view_close():
+	Logo_status_view_window.hide()
+
+func _on_logo_status_view_visibility_changed():
+	if Logo_status_view_window.visible:
+		$LogoStatusViewWindow/ScrollContainer.scroll_horizontal = 0
+		$LogoStatusViewWindow/ScrollContainer.scroll_vertical = 0
 
 func find_chat_node():
 	chat_node = find_node_recursive(get_tree().get_root(), "Chat")
@@ -250,6 +265,7 @@ func build_main_menu():
 	add_custom_item("Counters", 107)
 	add_custom_item("Summon Token", 106)
 	add_custom_item("Summon Mastery", 109)
+	add_custom_item("Summon Status", 110)
 	add_custom_item("Surrender", 103, {}, true)
 	finalize_custom_menu()
 
@@ -510,6 +526,11 @@ func _handle_menu_action(id, metadata = {}):
 			Logo_mastery_view_window.popup_centered()
 			$LogoMasteryViewWindow/ScrollContainer.call_deferred("set", "scroll_horizontal", 0)
 			$LogoMasteryViewWindow/ScrollContainer.call_deferred("set", "scroll_vertical", 0)
+		elif id == 110:
+			logo_menu.hide()
+			Logo_status_view_window.popup_centered()
+			$LogoStatusViewWindow/ScrollContainer.call_deferred("set", "scroll_horizontal", 0)
+			$LogoStatusViewWindow/ScrollContainer.call_deferred("set", "scroll_vertical", 0)
 		elif id == 103:
 			logo_menu.hide()
 			send_to_chat("Surrendered")
@@ -719,4 +740,28 @@ func create_card_display_mastery(card_name: String):
 	card_display.set_meta("slug", card_name)
 	card_display.set_meta("uuid", "")
 	card_display.set_meta("zone", "logo_mastery")
+	return card_display
+
+func populate_status():
+	for child in status_grid_container.get_children():
+		child.queue_free()
+	if status_slugs.is_empty():
+		status_slugs = fetch_slugs_by_type("STATUS")
+	status_slugs.sort()
+	for slug in status_slugs:
+		var card_display = create_card_display_status(slug)
+		status_grid_container.add_child(card_display)
+	status_grid_container.anchor_left = 0
+	status_grid_container.anchor_top = 0
+	status_grid_container.anchor_right = 1
+	status_grid_container.anchor_bottom = 1
+	status_grid_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	status_grid_container.size_flags_vertical = Control.SIZE_EXPAND_FILL
+
+func create_card_display_status(card_name: String):
+	var card_display_scene = preload("res://Scenes/CardDisplay.tscn")
+	var card_display = card_display_scene.instantiate()
+	card_display.set_meta("slug", card_name)
+	card_display.set_meta("uuid", "")
+	card_display.set_meta("zone", "logo_status")
 	return card_display

--- a/Scripts/Multiplayer.gd
+++ b/Scripts/Multiplayer.gd
@@ -588,6 +588,7 @@ func sync_move_to_main_field(player_id: int, uuid: String, slug: String, pos: Ve
 				elif opp_main and opp_main.has_method("add_card_to_field"):
 					var is_token = false
 					var is_mastery = false
+					var is_status = false
 					var logos = get_tree().get_nodes_in_group("logo")
 					if logos.size() > 0:
 						var local_logo = logos[0]
@@ -595,7 +596,9 @@ func sync_move_to_main_field(player_id: int, uuid: String, slug: String, pos: Ve
 							is_token = true
 						if "mastery_slugs" in local_logo and slug in local_logo.mastery_slugs:
 							is_mastery = true
-					if (is_token or is_mastery) and not (card in opp_main.cards_in_field):
+						if "status_slugs" in local_logo and slug in local_logo.status_slugs:
+							is_status = true
+					if (is_token or is_mastery or is_status) and not (card in opp_main.cards_in_field):
 						var opp_logo = null
 						for child in opp_field.get_children():
 							if "Logo" in child.name:


### PR DESCRIPTION
Introduce a new 'status' card type alongside tokens and mastery: add a Logo status view window and grid (LogoStatusViewWindow) and populate/create helpers in Logo.gd. Implement card-level support in Card.gd (is_status, destroy_status) and expose status-specific popup/menu actions and behavior (destroy, Awake/Rest). Update CardDisplay.gd to treat logo_status like other logo zones (disable popups/drags where appropriate) and CardManager.gd to handle status drops, duplicate status removal on MAINFIELD, and destruction when placed in invalid slots. Add get_card_name_from_slug helper to CardManager and extend Multiplayer.gd sync_move_to_main_field to recognize status slugs. Also include scene adjustments (Elements & Opponent_Elements position tweaks) and add the new LogoStatusViewWindow nodes to Logo.tscn.